### PR TITLE
Remove health check

### DIFF
--- a/seed/docker-compose.yml
+++ b/seed/docker-compose.yml
@@ -21,7 +21,3 @@ services:
     volumes:
       - ${PWD}/qgs:/data
       - ${GEODATA_PATH:-./geodata}:/geodata
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/qgis/ch.so.agi.hintergrundkarte_sw"]
-      interval: 30s
-      timeout: 3s


### PR DESCRIPTION
Reason: Don't force to have the LK SW data present even if one wants to seed only the LK color or orthophoto layer