### PR TITLE
The tiles should not expire

### DIFF
--- a/mapcache.xml
+++ b/mapcache.xml
@@ -83,7 +83,6 @@
     <metatile>8 8</metatile>
     <metabuffer>0</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_farbig">
@@ -94,7 +93,6 @@
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_sw">
@@ -105,7 +103,6 @@
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <default_format>JPEG</default_format>

--- a/mapcache.xml
+++ b/mapcache.xml
@@ -82,7 +82,7 @@
     <format>myjpeg</format>
     <metatile>8 8</metatile>
     <metabuffer>0</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_farbig">
@@ -92,7 +92,7 @@
     <format>PNG</format>
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_sw">
@@ -102,7 +102,7 @@
     <format>PNG</format>
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <default_format>JPEG</default_format>

--- a/mapcacheproduction.xml
+++ b/mapcacheproduction.xml
@@ -83,7 +83,6 @@
     <metatile>8 8</metatile>
     <metabuffer>0</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_farbig">
@@ -94,7 +93,6 @@
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_sw">
@@ -105,7 +103,6 @@
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <default_format>JPEG</default_format>

--- a/mapcacheproduction.xml
+++ b/mapcacheproduction.xml
@@ -82,7 +82,7 @@
     <format>myjpeg</format>
     <metatile>8 8</metatile>
     <metabuffer>0</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_farbig">
@@ -92,7 +92,7 @@
     <format>PNG</format>
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_sw">
@@ -102,7 +102,7 @@
     <format>PNG</format>
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <default_format>JPEG</default_format>

--- a/mapcachetest.xml
+++ b/mapcachetest.xml
@@ -83,7 +83,6 @@
     <metatile>8 8</metatile>
     <metabuffer>0</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_farbig">
@@ -94,7 +93,6 @@
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_sw">
@@ -105,7 +103,6 @@
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
     <expires>25200</expires>
-    <auto_expire>31536000</auto_expire>
   </tileset>
 
   <default_format>JPEG</default_format>

--- a/mapcachetest.xml
+++ b/mapcachetest.xml
@@ -82,7 +82,7 @@
     <format>myjpeg</format>
     <metatile>8 8</metatile>
     <metabuffer>0</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_farbig">
@@ -92,7 +92,7 @@
     <format>PNG</format>
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <tileset name="ch.so.agi.hintergrundkarte_sw">
@@ -102,7 +102,7 @@
     <format>PNG</format>
     <metatile>8 8</metatile>
     <metabuffer>20</metabuffer>
-    <expires>25200</expires>
+    <expires>28800</expires>
   </tileset>
 
   <default_format>JPEG</default_format>


### PR DESCRIPTION
Die Konfigurations-Option `auto_expire` braucht es nicht, da wir uns ja um die Aktualisierung der Tiles kümmern: wir aktualisieren sie entweder, nachdem neue Orthofotos oder Landeskarten-Dateien geliefert worden sind, oder bei den AV-Daten dann, wenn eine neue Gemeinde geliefert worden ist. Die Option hat vor allem die negative Auswirkung, dass Tiles, die vor mehr als einem Jahr erstellt worden sind, von MapCache neu erstellt werden beim nächsten Zugriff durch einen Client. Dies beeinträchtigt jedoch die Performance des MapCache.

Nun wird dem Browser Cache auch mitgeteilt, dass die ausgelieferten Kacheln nach 8h ablaufen, dass der Browser beim nächsten Zugriff auf dieselbe Kachel 8h später sie also neu herunterladen muss. Bisher war dieser Wert bei 7h, und ich bin der Meinung, dass man dies noch etwas erhöhen kann.