### PR TITLE
Send health check requests to a separate access log file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ RUN mkdir -p /var/run/apache2 && \
     chmod --recursive g+w /var/log/apache2 /var/run/apache2 && \
     sed -i -e 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 # Truncate Apache access logs after a certain time using rotatelogs, and send error messages to standard output
-RUN sed -i -E -e 's/^(CustomLog) (\S*) (\S*)/\1 "|\/usr\/bin\/rotatelogs -t \2 604800" \3/' \
-    -e '2 a ErrorLog "|\/bin\/cat"' \
+RUN sed -i -E -e '2 i SetEnvIf User-Agent ^kube-probe is_health_check' \
+    -e 's/^(CustomLog) (\S*) (\S*)/\1 "|\/usr\/bin\/rotatelogs -t \2 604800" \3 env=!is_health_check/' \
+    -e '3 i CustomLog "|/usr/bin/rotatelogs -t ${APACHE_LOG_DIR}/other_vhosts_access_health_checks.log 900" vhost_combined env=is_health_check' \
+    -e '3 i ErrorLog "|\/bin\/cat"' \
     /etc/apache2/conf-available/other-vhosts-access-log.conf
 
 # Configure and enable MapCache

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ## Build 
 
 ```
-docker build -t sogis/mapcache:latest .
+docker build -t sogis/docker-mapcache .
 ```
 
 ## Run
 ```
-docker run -e ENVIRONMENT='' -p 8281:8080 -v /tmp:/tiles --rm --name mapcache sogis/mapcache
+docker run -e ENVIRONMENT='' -p 8281:8080 -v /tmp:/tiles --rm --name mapcache sogis/docker-mapcache
 ```
 
 Log into container:


### PR DESCRIPTION
And truncate this log file after 15 minutes.