### PR TITLE
Upgrade to Debian testing and MapCache 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN chown --recursive root:root /var/log/apache2 /var/run/apache2 && \
     sed -i -e 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 # Truncate Apache access logs after a certain time using rotatelogs, and send error messages to standard output
 RUN sed -i -E \
-    -e 's/^(CustomLog) (\S*) (\S*)/\1 "|\/bin\/cat" \3/' \
-    -e '3 i ErrorLog "|\/bin\/cat"' \
+    -e "s/^(CustomLog) (\S*) (\S*)/\1 \"|\/bin\/cat\" \3 \"expr=osenv('APACHE_ACCESS_LOG_ENABLED') == 'true'\"/" \
+    -e "3 i ErrorLog \"|\/bin\/cat\"" \
     /etc/apache2/conf-available/other-vhosts-access-log.conf
 
 # Configure and enable MapCache

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Configuration for running Apache as non-root user
-RUN mkdir -p /var/run/apache2 && \
-    chown --recursive root:root /var/log/apache2 /var/run/apache2 && \
+RUN chown --recursive root:root /var/log/apache2 /var/run/apache2 && \
     chmod --recursive g+w /var/log/apache2 /var/run/apache2 && \
     sed -i -e 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 # Truncate Apache access logs after a certain time using rotatelogs, and send error messages to standard output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM debian:bookworm
 
+ENV HOME=/home/appuser
+ARG UID=999
+RUN useradd --system --uid $UID --gid 0 appuser && \
+    mkdir --mode=g+w $HOME
+
 RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends apache2 libapache2-mod-mapcache mapcache-tools ca-certificates rsync && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Configuration for running Apache as non-root user
-RUN chown --recursive root:root /var/log/apache2 /var/run/apache2 && \
+RUN chgrp --recursive 0 /var/log/apache2 /var/run/apache2 && \
     chmod --recursive g+w /var/log/apache2 /var/run/apache2 && \
     sed -i -e 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 # Truncate Apache access logs after a certain time using rotatelogs, and send error messages to standard output
@@ -28,7 +33,7 @@ VOLUME ["/tiles"]
 
 EXPOSE 8080
 
-USER 1001
+USER $UID
 
 ENTRYPOINT ["/mapcache/setup_configfile.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN chown --recursive root:root /var/log/apache2 /var/run/apache2 && \
     chmod --recursive g+w /var/log/apache2 /var/run/apache2 && \
     sed -i -e 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 # Truncate Apache access logs after a certain time using rotatelogs, and send error messages to standard output
-RUN sed -i -E -e 's/^(CustomLog) (\S*) (\S*)/\1 "|\/usr\/bin\/rotatelogs -n 3 \2 86400" \3/' \
+RUN sed -i -E \
+    -e 's/^(CustomLog) (\S*) (\S*)/\1 "|\/bin\/cat" \3/' \
     -e '3 i ErrorLog "|\/bin\/cat"' \
     /etc/apache2/conf-available/other-vhosts-access-log.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends apache2 libapache2-mod-mapcache mapcache-tools ca-certificates rsync && \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker-mapcache
 
+Docker image providing a MapCache WMTS
+
 ## Build 
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following environment variables may be passed:
 -e SERVICE_URL=https://geo-t.so.ch/api # The base URL of the MapCache service
 -e SOURCE_URL=https://geo-t.so.ch/api/wms # The base URL of the source WMS
 -e DEMO_SERVICE_ENABLED=true # Enable the MapCache demo service (a basic map viewer)
+-e APACHE_ACCESS_LOG_ENABLED=true # Print Apache access log to standard output
 ```
 
 Log into container:


### PR DESCRIPTION
Additionally:
* Send Apache access log to standard out, if `APACHE_ACCESS_LOG_ENABLED` env variable is set to `true`
* Create an app user