### PR TITLE
Update the seeding docs

### DIFF
--- a/seed/README.md
+++ b/seed/README.md
@@ -50,7 +50,7 @@ unzip $GEODATA_PATH/ch.so.agi.av.hoheitsgrenzen.gpkg.zip -d $GEODATA_PATH/ch.so.
 
 ### Rasterdaten auf dem WMTS-Extent zuschneiden
 
-Fürs Seeden der WMTS-Kacheln wird ein auf dem COG basierenes VRT mit reduziertem Extent erstellt (nur für die Varianten *farbig_relief* und *grau* bzw. *grau_relief*).
+Fürs Seeden der WMTS-Kacheln wird ein auf dem COG basierendes VRT mit reduziertem Extent erstellt (nur für die Varianten *farbig_relief* und *grau* bzw. *grau_relief*).
 Hierfür jeweils eine der folgenden Umgebungsvariablen-Kombinationen setzen und danach den untenstehenden Befehl ausführen:
 ```sh
 # Swiss Map Raster 10
@@ -96,7 +96,7 @@ Definieren, wo die Geodaten liegen und wo die Kacheln erstellt werden sollen:
 
 ```sh
 export GEODATA_PATH=$HOME/geodata
-export TILES_PATH=/tmp/tiles
+export TILES_PATH=$HOME/tiles
 ```
 
 Verzeichnis für die Tiles anlegen:
@@ -223,7 +223,7 @@ Falls man noch weitere Änderungen an den *.qgs*-Dokumenten machen muss, muss ma
 Zunächst muss der Inhalt des `$TILES_PATH` kurz überprüft werden. Danach meldet man sich an OpenShift an und kopiert mit folgenden Befehlsvorlagen die Kacheln auf einen der *MapCache*-Pods. Danach müssen **alle** *MapCache*-Pods neu gestartet werden, z.B. mit `oc delete pod ...`. Der Neustart ist nötig, damit Dateien, auf die der Service während des Kopierens noch zugegriffen hat, freigegeben werden und dadurch auch tatsächlich gelöscht werden.
 
 ```sh
-oc rsync --no-perms --progress ${TILES_PATH:-/tmp/tiles}/ mapcache-65-srz54:/tiles
+oc rsync --no-perms --progress ${TILES_PATH:-$HOME/tiles}/ mapcache-65-srz54:/tiles
 oc delete pod mapcache-65-srz54
 oc delete pod mapcache-65-vm8jg
 ```

--- a/seed/README.md
+++ b/seed/README.md
@@ -1,67 +1,83 @@
 # WMTS-Kacheln seeden
 
-Mit dieser Anleitung und der dazugehörigen Umgebung (_Docker Compose_) können WMTS-Kacheln auf einem anderen System als auf dem produktiven WMTS geseedet werden (z.B. auf der lokalen Maschine). Die fertigen Kacheln müssen danach nur noch auf das produktive System kopiert werden.
+Mit dieser Anleitung und der dazugehörigen Umgebung (_Docker Compose_) können WMTS-Kacheln auf einer lokalen Maschine geseedet und die fertigen Kacheln danach auf das produktive System kopiert werden.
+Dadurch fällt die Last nicht auf dem produktiven System an.
 
 
-## Bereitstellen der Geodaten auf einer lokalen Maschine im AGI
+## Geodaten lokal bereitstellen
 
 Zunächst muss man entscheiden, wo auf dem lokalen Rechner die Daten abgelegt werden sollen. Dieser Pfad muss in der Umgebungsvariable `GEODATA_PATH` gespeichert und danach das entsprechende Verzeichnis angelegt werden, z.B.:
 
-```
+```sh
 export GEODATA_PATH=$HOME/geodata
 mkdir $GEODATA_PATH
 ```
 
-Die benötigten Geodaten kopiert man mit `rsync` hierher bzw. generiert man mit ogr2ogr;
-wahrscheinlich ist es häufig sinnvoll,
-den `rsync`-Befehlen zudem die Option `--delete` mitzugeben,
-damit im Quellverzeichnis nicht mehr vorhandene Dateien
-aus dem Zielverzeichnis gelöscht werden:
+### Rasterdaten
 
+Die benötigten Geodaten kopiert man mit folgenden Befehlen auf die lokale Maschine.
+Bei einem Update der Hintergrundkarten sind sie möglicherweise bereits lokal vorhanden; dann kann man diesen Schritt hier überspringen.
 ```
-rsync -a --info=progress2 $USER@UTIL-SERVERNAME:/opt/sogis_pic/geodata/ch.swisstopo.lk* $GEODATA_PATH
-rsync -a --info=progress2 $USER@UTIL-SERVERNAME:/opt/sogis_pic/geodata/ch.so.agi.hintergrundkarte $GEODATA_PATH
-# Beim folgenden Befehl besser user und password weglassen und dies stattdessen in Datei .pgpass erfassen
-ogr2ogr -f GPKG -overwrite $GEODATA_PATH/hoheitsgrenzen_kantonsgrenze.gpkg PG:'host=xy dbname=pub user=xy password=xy' -nln hoheitsgrenzen_kantonsgrenze agi_hoheitsgrenzen_pub.hoheitsgrenzen_kantonsgrenze
-rsync -a --info=progress2 $USER@UTIL-SERVERNAME:/opt/sogis_pic/geodata/ch.swisstopo.swissimage_2024.rgb $GEODATA_PATH
-rsync -a --info=progress2 $USER@UTIL-SERVERNAME:/opt/sogis_pic/geodata/ch.swisstopo.sentinel_2018 $GEODATA_PATH
+rsync --delete -a --chmod=D0775,F0664 --info=progress2 ~/shares/sogisgeodata/geodata/ch.swisstopo.lk* $GEODATA_PATH
+rsync --delete -a --chmod=D0775,F0664 --info=progress2 ~/shares/sogisgeodata/geodata/ch.swisstopo.swissimage_2024.rgb $GEODATA_PATH
+rsync --delete -a --chmod=D0775,F0664 --info=progress2 ~/shares/sogisgeodata/geodata/ch.swisstopo.sentinel_2018 $GEODATA_PATH
 ```
 
-Nun kann man gemäss der Anleitung im Abschnit _Kacheln erstellen (seeden)_ mit dem Seeden starten.
-
-
-### Optional: Bereitstellen der Geodaten auf einer beliebigen lokalen Maschine
-
-Falls man die Kacheln auf einer externen Maschine seeden möchte, muss man zunächst ebenfalls auf der AGI-Maschine die obigen Schritte ausführen, um die Geodaten auf die AGI-Maschine zu kopieren. Danach speichert man sie entweder auf einer externen Festplatte und transferiert sie auf die externe Maschine, wobei auch dort wieder ein `$GEODATA_PATH` angelegt werden muss, wohin man danach die Daten kopiert:
-
+Falls sich die Maschine ausserhalb des Kantonsnetzwerks befindet, kann man die Daten alternativ mit folgenden Befehlen herunterladen, wobei man aber drauf achten muss, dass man den Server files.geo.so.ch nicht überlastet:
+```sh
+export PRODUCT=lk10; export VARIANT=farbig_relief
+# (usw., Umgebungsvariablen-Kombinationen siehe im übernächsten Abschnitt)
 ```
-export GEODATA_PATH=$HOME/geodata
-mkdir $GEODATA_PATH
+```sh
+mkdir $GEODATA_PATH/ch.swisstopo.${PRODUCT}.${VARIANT}
+wget https://files.geo.so.ch/ch.swisstopo.${PRODUCT}.${VARIANT}/aktuell/ch.swisstopo.${PRODUCT}.${VARIANT}.tif -P $GEODATA_PATH/ch.swisstopo.${PRODUCT}.${VARIANT}
+mkdir $GEODATA_PATH/ch.swisstopo.swissimage_2024.rgb
+wget https://files.geo.so.ch/ch.swisstopo.swissimage_2024.rgb/aktuell/ch.swisstopo.swissimage_2024.rgb.tif -P $GEODATA_PATH/ch.swisstopo.swissimage_2024.rgb
+mkdir $GEODATA_PATH/ch.swisstopo.sentinel_2018
+wget https://files.geo.so.ch/ch.swisstopo.sentinel_2018/aktuell/ch.swisstopo.sentinel_2018.tif -P $GEODATA_PATH/ch.swisstopo.sentinel_2018
 ```
 
-Oder man packt die Daten in ein Archiv und überträgt sie übers Internet. (Die Landeskarten sind allerdings ca. 12GB gross, die Orthofotos 26GB.)
+### Hoheitsgrenzen
 
-Packen auf der AGI-Maschine:
-
+Die in jedem Fall zusätzlich benötigten Hoheitsgrenzen lädt man mit folgendem Befehl herunter:
+```sh
+wget https://files.geo.so.ch/ch.so.agi.av.hoheitsgrenzen/aktuell/ch.so.agi.av.hoheitsgrenzen.gpkg.zip -P $GEODATA_PATH/
 ```
-cd $GEODATA_PATH
-tar -czf lk.tar.gz ch.swisstopo.lk*
-tar -czf maske.tar.gz ch.so.agi.hintergrundkarte/maske.tif
-tar -czf ch.swisstopo.swissimage_2018.rgb.tar.gz ch.swisstopo.swissimage_2018.rgb
-tar -czf ch.swisstopo.sentinel_2018.tar.gz ch.swisstopo.sentinel_2018
+Entpacken:
+```sh
+unzip $GEODATA_PATH/ch.so.agi.av.hoheitsgrenzen.gpkg.zip -d $GEODATA_PATH/ch.so.agi.av.hoheitsgrenzen
 ```
-(`hoheitsgrenzen_kantonsgrenze.gpkg` muss nicht gepackt werden, und `ch.swisstopo.sentinel_2018` packen wir nur deshalb, weil beim Entpacken praktischerweise auch der richtige Unterordner angelegt wird.)
 
-Entpacken auf der externen Maschine:
+### Rasterdaten auf dem WMTS-Extent zuschneiden
 
+Fürs Seeden der WMTS-Kacheln wird ein auf dem COG basierenes VRT mit reduziertem Extent erstellt (nur für die Varianten *farbig_relief* und *grau* bzw. *grau_relief*).
+Hierfür jeweils eine der folgenden Umgebungsvariablen-Kombinationen setzen und danach den untenstehenden Befehl ausführen:
+```sh
+# Swiss Map Raster 10
+export PRODUCT=lk10; export VARIANT=farbig_relief
+export PRODUCT=lk10; export VARIANT=grau_relief
+# Swiss Map Raster 25
+export PRODUCT=lk25; export VARIANT=farbig_relief
+export PRODUCT=lk25; export VARIANT=grau
+# Swiss Map Raster 50
+export PRODUCT=lk50; export VARIANT=farbig_relief
+export PRODUCT=lk50; export VARIANT=grau
+# Swiss Map Raster 100
+export PRODUCT=lk100; export VARIANT=farbig_relief
+export PRODUCT=lk100; export VARIANT=grau
+# Swiss Map Raster 200
+export PRODUCT=lk200; export VARIANT=farbig_relief
+export PRODUCT=lk200; export VARIANT=grau
+# Swiss Map Raster 500
+export PRODUCT=lk500; export VARIANT=farbig_relief
+export PRODUCT=lk500; export VARIANT=grau
+# Swiss Map Raster 1000
+export PRODUCT=lk1000; export VARIANT=farbig_relief
+export PRODUCT=lk1000; export VARIANT=grau_relief
 ```
-export GEODATA_PATH=$HOME/geodata
-mkdir $GEODATA_PATH
-cd $GEODATA_PATH
-tar -xzf lk.tar.gz
-tar -xzf maske.tar.gz
-tar -xzf ch.swisstopo.swissimage_2018.rgb.tar.gz
-tar -xzf ch.swisstopo.sentinel_2018.tar.gz
+```sh
+cd $GEODATA_PATH/ch.swisstopo.${PRODUCT}.${VARIANT}
+gdal_translate -of VRT -projwin 2570000 1268000 2667000 1208000 ch.swisstopo.${PRODUCT}.${VARIANT}.tif ch.swisstopo.${PRODUCT}-masked.${VARIANT}.vrt
 ```
 
 
@@ -71,32 +87,46 @@ tar -xzf ch.swisstopo.sentinel_2018.tar.gz
 
 Git-Repository auschecken und ins `seed`-Unterverzeichnis wechseln:
 
-```
+```sh
 git clone https://github.com/sogis/docker-mapcache.git && cd docker-mapcache
 cd seed
 ```
 
 Definieren, wo die Geodaten liegen und wo die Kacheln erstellt werden sollen:
 
-```
+```sh
 export GEODATA_PATH=$HOME/geodata
 export TILES_PATH=/tmp/tiles
 ```
 
-Verzeichnis für die Tiles anlegen und benötigte Berechtigungen setzen:
+Verzeichnis für die Tiles anlegen:
 
+```sh
+mkdir $TILES_PATH
 ```
-mkdir -m 0777 $TILES_PATH
-```
 
-#### Nur bei Bedarf: Änderungen an *.qgs*-Dokumenten vornehmen
+### Nur bei Bedarf: Änderungen an *.qgs*-Dokumenten vornehmen
 
-Einige Änderungen können möglicherweise mit einem Skript realisiert werden,
-z.B. die Änderung eines Orthofoto-Standes mit folgedem Befehl:
+Falls Änderungen an den *.qgs*-Dokumenten nötig sein sollten, können kleinere Anpassungen möglicherweise mit einem Skript realisiert werden.
+Z.B. für die Änderung eines Orthofoto-Standes:
 
-```
+```sh
 sed -i -E 's/swissimage_2021/swissimage_2024/g' qgs/ch.so.agi.hintergrundkarte_ortho.qgs
 ```
+Falls hingegen manuelle Änderungen an *.qgs*-Dokumenten notwendig sind, kann man mit dem folgenden Befehl einen Docker-Container mit der passenden QGIS-Version starten und die Anpassungen dort vornehmen:
+```sh
+docker run -it --rm --name qgis -u $UID \
+-e HOME=/home/$UID -e DISPLAY=$DISPLAY -e GDAL_PAM_ENABLED=NO \
+-v /tmp/.X11-unix:/tmp/.X11-unix -v /tmp:/home/$UID \
+-v ./qgs:/home/$UID/qgs -v $GEODATA_PATH:/geodata \
+qgis/qgis:final-3_28_7 qgis
+```
+
+Die Geodaten sind hierbei unter `/geodata` verfügbar.
+Zu beachten ist beim Editieren, dass die Pfade zu den Geodaten *absolut* gespeichert sein müssen.
+(Der Pfad zu den geladenen Geodaten muss also mit `/geodata` beginnen.)
+
+### Nur bei Bedarf: Änderungen an *.qgs*-Dokumenten mittels Vagrant Box vornehmen (veraltet)
 
 Falls vor dem Seeden hingegen manuelle Änderungen
 an *.qgs*-Dokumenten notwendig sind,
@@ -144,54 +174,56 @@ Diese Einstellung ist unter *Project > Properties / General* zu finden.
 
 ### Seeden
 
-Die aktuellsten Images pullen:
+Die aktuellsten Docker Images pullen:
 
-```
+```sh
 docker compose pull
 ```
 
 Den WMS starten:
 
-```
+```sh
 docker compose up -d wms
 ```
 
-Seeden nach Bedarf:
+Seeden:
 
-```
-docker compose run --rm --service-ports -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_sw seeder mapcache_seed -c /mapcache/mapcache.xml -t ch.so.agi.hintergrundkarte_sw -f -z 0,10 -n 4
-docker compose run --rm --service-ports -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_farbig seeder mapcache_seed -c /mapcache/mapcache.xml -t ch.so.agi.hintergrundkarte_farbig -f -z 0,10 -n 4
-docker compose run --rm --service-ports -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_ortho seeder mapcache_seed -c /mapcache/mapcache.xml -t ch.so.agi.hintergrundkarte_ortho -f -z 0,14 -n 4
+```sh
+# hintergrundkarte_farbig, nur die Landeskarten-Zoomstufen, Daucer ca. 10min:
+docker compose run --rm -u $UID -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_farbig wmts mapcache_seed -c /mapcache/mapcache.xml -t ch.so.agi.hintergrundkarte_farbig -f -z 0,10 -n 4
+# hintergrundkarte_sw, nur die Landeskarten-Zoomstufen, Dauer ca. 6min:
+docker compose run --rm -u $UID -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_sw wmts mapcache_seed -c /mapcache/mapcache.xml -t ch.so.agi.hintergrundkarte_sw -f -z 0,10 -n 4
+# hintergrundkarte_ortho, alle Zoomstufen:
+docker compose run --rm -u $UID -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_ortho wmts mapcache_seed -c /mapcache/mapcache.xml -t ch.so.agi.hintergrundkarte_ortho -f -z 0,14 -n 4
 ```
 Zur Information:
 * Der MapCache-Service ist während des Seedens nicht verfügbar
 * QGIS Server ist bei Bedarf unter z.B. der folgenden URL erreichbar:
   http://localhost:8081/qgis/ch.so.agi.hintergrundkarte_sw?SERVICE=WMS&REQUEST=GetCapabilities
 
-QGIS Server stoppen:
+Den WMS stoppen:
 
-```
+```sh
 docker compose down
 ```
 
-Resultat prüfen nach Bedarf:
+Um das Resultat zu prüfen den WMTS starten (nach Bedarf):
 
+```sh
+docker compose run --rm --service-ports wmts
 ```
-docker compose run --rm --service-ports -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_sw wmts
-docker compose run --rm --service-ports -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_farbig wmts
-docker compose run --rm --service-ports -e SOURCE_URL=http://wms/qgis/ch.so.agi.hintergrundkarte_ortho wmts
-```
-Danach http://localhost:8080/demo aufrufen und im WMTS-Viewer rechts aussen den entsprechenden Layer einschalten.
+Danach http://localhost:8080/demo/wmts aufrufen **und im Viewer auf den Plus-Button rechts oben klicken und dort den entsprechenden Layer einschalten**.
 
 
-Falls man noch weitere Änderungen an den .qgs-Dokumenten machen muss, führt man sicherheitshalber vor dem nächsten `docker compose run` ein `docker compose down` aus, damit die Änderungen übernommen werden.
+Falls man noch weitere Änderungen an den *.qgs*-Dokumenten machen muss, muss man vor dem nächsten Seeden ein `docker compose down` und `docker compose up -d wms` ausführen, damit die Änderungen übernommen werden.
 
-### Kacheln in OpenShift publizieren
 
-Zunächst muss der Inhalt des `$TILES_PATH` kurz überprüft werden. Danach meldet man sich an OpenShift an und kopiert mit folgenden Befehlsvorlagen die Kacheln auf einen der *MapCache*-Pods. Danach müssen **alle** *MapCache*-Pods neu gestartet werden, z.B. mit `oc delete pod ...`. Der Neustart ist nötig, damit Dateien, auf die der Service während des Kopierens noch zugegriffen hat, freigegeben werden.
+## Kacheln in OpenShift publizieren
 
-```
-oc rsync --no-perms --progress $TILES_PATH/ mapcache-65-srz54:/tiles
+Zunächst muss der Inhalt des `$TILES_PATH` kurz überprüft werden. Danach meldet man sich an OpenShift an und kopiert mit folgenden Befehlsvorlagen die Kacheln auf einen der *MapCache*-Pods. Danach müssen **alle** *MapCache*-Pods neu gestartet werden, z.B. mit `oc delete pod ...`. Der Neustart ist nötig, damit Dateien, auf die der Service während des Kopierens noch zugegriffen hat, freigegeben werden und dadurch auch tatsächlich gelöscht werden.
+
+```sh
+oc rsync --no-perms --progress ${TILES_PATH:-/tmp/tiles}/ mapcache-65-srz54:/tiles
 oc delete pod mapcache-65-srz54
 oc delete pod mapcache-65-vm8jg
 ```

--- a/seed/docker-compose.yml
+++ b/seed/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   wmts:
     image: sogis/mapcache:latest
@@ -8,21 +7,15 @@ services:
       - "8080:8080"
     volumes:
       - ${TILES_PATH}:/tiles
-  seeder:
-    image: sogis/mapcache:latest
-    environment:
-      DEMO_SERVICE_ENABLED: 'true'
-    volumes:
-      - ${TILES_PATH}:/tiles
-    depends_on:
-      - wms
   wms:
-    image: sogis/qgis-server-base:3.16
+    image: sourcepole/qwc-qgis-server:3.28.7
     environment:
-      QGIS_FCGI_MIN_PROCESSES: 4
-      QGIS_FCGI_MAX_PROCESSES: 4
+      URL_PREFIX: /qgis
+      FCGI_MIN_PROCESSES: 0
+      FCGI_MAX_PROCESSES: 4
+      FCGI_PROCESS_LIFE_TIME: 0
     ports:
       - "8081:80"
     volumes:
-      - ${PWD}/qgs:/data
-      - ${GEODATA_PATH:-./geodata}:/geodata
+      - ./qgs:/data
+      - ${GEODATA_PATH}:/geodata

--- a/seed/qgs/ch.so.agi.hintergrundkarte_farbig.qgs
+++ b/seed/qgs/ch.so.agi.hintergrundkarte_farbig.qgs
@@ -1,83 +1,95 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="ch.so.agi.hintergrundkarte_farbig" saveDateTime="2023-03-23T10:41:53" saveUser="vagrant" version="3.16.3-Hannover" saveUserFull="vagrant">
+<qgis saveDateTime="2025-07-14T08:14:52" projectname="" saveUser="" saveUserFull="" version="3.28.7-Firenze">
   <homePath path=""/>
-  <title>ch.so.agi.hintergrundkarte_farbig</title>
-  <autotransaction active="0"/>
-  <evaluateDefaultValues active="0"/>
-  <trust active="0"/>
+  <title></title>
+  <transaction mode="Disabled"/>
+  <projectFlags set=""/>
   <projectCrs>
-    <spatialrefsys>
-      <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-      <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+    <spatialrefsys nativeFormat="Wkt">
+      <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+      <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
       <srsid>47</srsid>
       <srid>2056</srid>
       <authid>EPSG:2056</authid>
       <description>CH1903+ / LV95</description>
       <projectionacronym>somerc</projectionacronym>
-      <ellipsoidacronym>bessel</ellipsoidacronym>
+      <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
       <geographicflag>false</geographicflag>
     </spatialrefsys>
   </projectCrs>
   <layer-tree-group>
-    <customproperties/>
-    <layer-tree-layer id="maske_f7b0abd0_8125_4bbb_81ae_f7567cdfbf2f" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="maske" source="/geodata/ch.so.agi.hintergrundkarte/maske.tif" patch_size="0,0">
-      <customproperties/>
+    <customproperties>
+      <Option/>
+    </customproperties>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk1000-masked.farbig_relief" id="ch_swisstopo_lk1000_masked_farbig_relief_9a6d25aa_790a_4712_a825_d7af03eee226" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk1000.farbig_relief/ch.swisstopo.lk1000-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="krel1000_289397dd_260e_4f4c_aab0_3671a1ff8bd5" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk1000.farbig_relief" source="/geodata/ch.swisstopo.lk1000.farbig_relief/lk1000_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk500-masked.farbig_relief" id="ch_swisstopo_lk500_masked_farbig_relief_0d96cfb8_4ecb_4d9b_8496_1d31648bb913" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk500.farbig_relief/ch.swisstopo.lk500-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="PK500_LV95_KREL_10L_Mosaic_2016_0d4cfbd3_ba37_4b44_87b5_b8129056b85d" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk500.farbig_relief" source="/geodata/ch.swisstopo.lk500.farbig_relief/lk500_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk200-masked.farbig_relief" id="ch_swisstopo_lk200_masked_farbig_relief_1f79ce90_1af9_4b1e_aa59_ff668811f81a" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk200.farbig_relief/ch.swisstopo.lk200-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk200_farbig_relief_4c9d7a53_9984_4494_90d7_7dbd2608443e" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk200.farbig_relief" source="/geodata/ch.swisstopo.lk200.farbig_relief/lk200_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk100-masked.farbig_relief" id="ch_swisstopo_lk100_masked_farbig_relief_98869cc9_398d_4df9_9624_b6073b0112ae" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk100.farbig_relief/ch.swisstopo.lk100-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk100_farbig_relief_22134aeb_3970_4315_83fc_c6cbe539f7e8" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk100.farbig_relief" source="/geodata/ch.swisstopo.lk100.farbig_relief/lk100_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk50-masked.farbig_relief" id="ch_swisstopo_lk50_masked_farbig_relief_11d41db6_2459_4aef_9d99_b8750bcdca69" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk50.farbig_relief/ch.swisstopo.lk50-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk50_farbig_relief_20181de5_d161_4c7e_a4c6_52d9d27c536c" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk50.farbig_relief" source="/geodata/ch.swisstopo.lk50.farbig_relief/lk50_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk25-masked.farbig_relief" id="ch_swisstopo_lk25_masked_farbig_relief_85fa40e2_b8b6_4a62_bdec_ce40fafcc9df" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk25.farbig_relief/ch.swisstopo.lk25-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk25_farbig_relief_1505020c_f825_4859_a2cc_05756a62a87a" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk25.farbig_relief" source="/geodata/ch.swisstopo.lk25.farbig_relief/lk25_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
-    </layer-tree-layer>
-    <layer-tree-layer id="lk10_farbig_relief_454f9144_ef6e_42c7_adbe_67217c448956" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk10.farbig_relief" source="/geodata/ch.swisstopo.lk10.farbig_relief/lk10_farbig_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer expanded="0" legend_exp="" name="ch.swisstopo.lk10-masked.farbig_relief" id="ch_swisstopo_lk10_masked_farbig_relief_d70c551d_07e6_4536_98f3_071067a3327a" legend_split_behavior="0" providerKey="gdal" checked="Qt::Checked" patch_size="-1,-1" source="/geodata/ch.swisstopo.lk10.farbig_relief/ch.swisstopo.lk10-masked.farbig_relief.vrt">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
-      <item>krel1000_289397dd_260e_4f4c_aab0_3671a1ff8bd5</item>
-      <item>PK500_LV95_KREL_10L_Mosaic_2016_0d4cfbd3_ba37_4b44_87b5_b8129056b85d</item>
-      <item>lk200_farbig_relief_4c9d7a53_9984_4494_90d7_7dbd2608443e</item>
-      <item>lk100_farbig_relief_22134aeb_3970_4315_83fc_c6cbe539f7e8</item>
-      <item>lk50_farbig_relief_20181de5_d161_4c7e_a4c6_52d9d27c536c</item>
-      <item>lk25_farbig_relief_1505020c_f825_4859_a2cc_05756a62a87a</item>
-      <item>lk10_farbig_relief_454f9144_ef6e_42c7_adbe_67217c448956</item>
-      <item>maske_f7b0abd0_8125_4bbb_81ae_f7567cdfbf2f</item>
+      <item>ch_swisstopo_lk10_masked_farbig_relief_d70c551d_07e6_4536_98f3_071067a3327a</item>
+      <item>ch_swisstopo_lk25_masked_farbig_relief_85fa40e2_b8b6_4a62_bdec_ce40fafcc9df</item>
+      <item>ch_swisstopo_lk50_masked_farbig_relief_11d41db6_2459_4aef_9d99_b8750bcdca69</item>
+      <item>ch_swisstopo_lk100_masked_farbig_relief_98869cc9_398d_4df9_9624_b6073b0112ae</item>
+      <item>ch_swisstopo_lk200_masked_farbig_relief_1f79ce90_1af9_4b1e_aa59_ff668811f81a</item>
+      <item>ch_swisstopo_lk500_masked_farbig_relief_0d96cfb8_4ecb_4d9b_8496_1d31648bb913</item>
+      <item>ch_swisstopo_lk1000_masked_farbig_relief_9a6d25aa_790a_4712_a825_d7af03eee226</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings maxScale="0" tolerance="12" self-snapping="0" scaleDependencyMode="0" enabled="0" minScale="0" unit="1" mode="2" type="1" intersection-snapping="0">
+  <snapping-settings mode="2" scaleDependencyMode="0" enabled="0" minScale="0" maxScale="0" type="1" unit="1" intersection-snapping="0" tolerance="12" self-snapping="0">
     <individual-layer-settings/>
   </snapping-settings>
   <relations/>
+  <polymorphicRelations/>
   <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>meters</units>
     <extent>
-      <xmin>2626229.59062500018626451</xmin>
-      <ymin>1256228.3812500003259629</ymin>
-      <xmax>2629281.15312500018626451</xmax>
-      <ymax>1258287.3656250003259629</ymax>
+      <xmin>2567178.65235065296292305</xmin>
+      <ymin>1195945.12270083441399038</ymin>
+      <xmax>2670267.3068186454474926</xmax>
+      <ymax>1280088.07492942898534238</ymax>
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
-      <spatialrefsys>
-        <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-        <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+        <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
         <srsid>47</srsid>
         <srid>2056</srid>
         <authid>EPSG:2056</authid>
         <description>CH1903+ / LV95</description>
         <projectionacronym>somerc</projectionacronym>
-        <ellipsoidacronym>bessel</ellipsoidacronym>
+        <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </destinationsrs>
@@ -86,50 +98,44 @@
   </mapcanvas>
   <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="maske">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="maske_f7b0abd0_8125_4bbb_81ae_f7567cdfbf2f" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk1000-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk1000_masked_farbig_relief_9a6d25aa_790a_4712_a825_d7af03eee226" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="ch.swisstopo.lk1000.farbig_relief">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="krel1000_289397dd_260e_4f4c_aab0_3671a1ff8bd5" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk500-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk500_masked_farbig_relief_0d96cfb8_4ecb_4d9b_8496_1d31648bb913" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk500.farbig_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="PK500_LV95_KREL_10L_Mosaic_2016_0d4cfbd3_ba37_4b44_87b5_b8129056b85d" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk200-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk200_masked_farbig_relief_1f79ce90_1af9_4b1e_aa59_ff668811f81a" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk200.farbig_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk200_farbig_relief_4c9d7a53_9984_4494_90d7_7dbd2608443e" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk100-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk100_masked_farbig_relief_98869cc9_398d_4df9_9624_b6073b0112ae" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk100.farbig_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk100_farbig_relief_22134aeb_3970_4315_83fc_c6cbe539f7e8" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk50-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk50_masked_farbig_relief_11d41db6_2459_4aef_9d99_b8750bcdca69" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk50.farbig_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk50_farbig_relief_20181de5_d161_4c7e_a4c6_52d9d27c536c" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk25-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk25_masked_farbig_relief_85fa40e2_b8b6_4a62_bdec_ce40fafcc9df" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk25.farbig_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk25_farbig_relief_1505020c_f825_4859_a2cc_05756a62a87a" visible="1"/>
-      </filegroup>
-    </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk10.farbig_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk10_farbig_relief_454f9144_ef6e_42c7_adbe_67217c448956" visible="1"/>
+    <legendlayer drawingOrder="-1" name="ch.swisstopo.lk10-masked.farbig_relief" checked="Qt::Checked" showFeatureCount="0" open="false">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk10_masked_farbig_relief_d70c551d_07e6_4536_98f3_071067a3327a" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
-  <mapViewDocks3D/>
-  <main-annotation-layer autoRefreshEnabled="0" type="annotation" refreshOnNotifyEnabled="0" autoRefreshTime="0" refreshOnNotifyMessage="">
+  <main-annotation-layer refreshOnNotifyEnabled="0" legendPlaceholderImage="" type="annotation" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
     <id>Annotations_3afc30ad_8589_459e_9d7a_f7afd4f5b89d</id>
     <datasource></datasource>
     <keywordList>
@@ -137,15 +143,15 @@
     </keywordList>
     <layername></layername>
     <srs>
-      <spatialrefsys>
-        <wkt></wkt>
-        <proj4></proj4>
-        <srsid>0</srsid>
-        <srid>0</srid>
-        <authid></authid>
-        <description></description>
-        <projectionacronym></projectionacronym>
-        <ellipsoidacronym></ellipsoidacronym>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+        <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <srsid>47</srsid>
+        <srid>2056</srid>
+        <authid>EPSG:2056</authid>
+        <description>CH1903+ / LV95</description>
+        <projectionacronym>somerc</projectionacronym>
+        <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </srs>
@@ -160,7 +166,7 @@
       <fees></fees>
       <encoding></encoding>
       <crs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt></wkt>
           <proj4></proj4>
           <srsid>0</srsid>
@@ -176,31 +182,39 @@
     </resourceMetadata>
     <items/>
     <layerOpacity>1</layerOpacity>
+    <blendMode>0</blendMode>
+    <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer maxScale="150000" hasScaleBasedVisibilityFlag="1" minScale="280000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="1e+08" maxScale="280000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2443000</xmin>
-        <ymin>1024000</ymin>
-        <xmax>2895000</xmax>
-        <ymax>1340000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>PK500_LV95_KREL_10L_Mosaic_2016_0d4cfbd3_ba37_4b44_87b5_b8129056b85d</id>
-      <datasource>/geodata/ch.swisstopo.lk500.farbig_relief/lk500_farbig_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk1000_masked_farbig_relief_9a6d25aa_790a_4712_a825_d7af03eee226</id>
+      <datasource>/geodata/ch.swisstopo.lk1000.farbig_relief/ch.swisstopo.lk1000-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk500.farbig_relief</layername>
+      <layername>ch.swisstopo.lk1000-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -224,7 +238,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -233,11 +247,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -256,28 +270,130 @@
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="114,155,111,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="114,155,111,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="-1">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -287,37 +403,58 @@
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="280000" hasScaleBasedVisibilityFlag="1" minScale="1e+8" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="70000" maxScale="35000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2317000</xmin>
-        <ymin>913000</ymin>
-        <xmax>3057000</xmax>
-        <ymax>1413000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>krel1000_289397dd_260e_4f4c_aab0_3671a1ff8bd5</id>
-      <datasource>/geodata/ch.swisstopo.lk1000.farbig_relief/lk1000_farbig_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk100_masked_farbig_relief_98869cc9_398d_4df9_9624_b6073b0112ae</id>
+      <datasource>/geodata/ch.swisstopo.lk100.farbig_relief/ch.swisstopo.lk100-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk1000.farbig_relief</layername>
+      <layername>ch.swisstopo.lk100-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -341,7 +478,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -350,11 +487,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -373,28 +510,130 @@
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="232,113,141,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="232,113,141,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="4" zoomedOutResamplingMethod="bilinear" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="-1">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -404,37 +643,58 @@
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>86</minValue>
+            <maxValue>248</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>70</minValue>
+            <maxValue>249</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>57</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="35000" hasScaleBasedVisibilityFlag="1" minScale="70000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="9000" maxScale="5000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2550000</xmin>
-        <ymin>1206000</ymin>
-        <xmax>2690000</xmax>
-        <ymax>1302000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk100_farbig_relief_22134aeb_3970_4315_83fc_c6cbe539f7e8</id>
-      <datasource>/geodata/ch.swisstopo.lk100.farbig_relief/lk100_farbig_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk10_masked_farbig_relief_d70c551d_07e6_4536_98f3_071067a3327a</id>
+      <datasource>/geodata/ch.swisstopo.lk10.farbig_relief/ch.swisstopo.lk10-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk100.farbig_relief</layername>
+      <layername>ch.swisstopo.lk10-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -458,7 +718,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -467,11 +727,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -490,28 +750,130 @@
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="231,113,72,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="231,113,72,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="4">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -521,37 +883,58 @@
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="5000" hasScaleBasedVisibilityFlag="1" minScale="9000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="150000" maxScale="70000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2585000</xmin>
-        <ymin>1212000</ymin>
-        <xmax>2655000</xmax>
-        <ymax>1266000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk10_farbig_relief_454f9144_ef6e_42c7_adbe_67217c448956</id>
-      <datasource>/geodata/ch.swisstopo.lk10.farbig_relief/lk10_farbig_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk200_masked_farbig_relief_1f79ce90_1af9_4b1e_aa59_ff668811f81a</id>
+      <datasource>/geodata/ch.swisstopo.lk200.farbig_relief/ch.swisstopo.lk200-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk10.farbig_relief</layername>
+      <layername>ch.swisstopo.lk200-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -575,7 +958,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -584,11 +967,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -607,28 +990,130 @@
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="141,90,153,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="141,90,153,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="4">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -638,37 +1123,58 @@
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>68</minValue>
+            <maxValue>253</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>70</minValue>
+            <maxValue>253</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>36</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="70000" hasScaleBasedVisibilityFlag="1" minScale="150000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="18000" maxScale="9000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2443000</xmin>
-        <ymin>1024000</ymin>
-        <xmax>2895000</xmax>
-        <ymax>1340000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk200_farbig_relief_4c9d7a53_9984_4494_90d7_7dbd2608443e</id>
-      <datasource>/geodata/ch.swisstopo.lk200.farbig_relief/lk200_farbig_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk25_masked_farbig_relief_85fa40e2_b8b6_4a62_bdec_ce40fafcc9df</id>
+      <datasource>/geodata/ch.swisstopo.lk25.farbig_relief/ch.swisstopo.lk25-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk200.farbig_relief</layername>
+      <layername>ch.swisstopo.lk25-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -692,7 +1198,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -701,11 +1207,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -724,28 +1230,130 @@
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="183,72,75,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="183,72,75,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="4">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -755,37 +1363,58 @@
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>252</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>251</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="9000" hasScaleBasedVisibilityFlag="1" minScale="18000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="280000" maxScale="150000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2585000</xmin>
-        <ymin>1206000</ymin>
-        <xmax>2655000</xmax>
-        <ymax>1266000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk25_farbig_relief_1505020c_f825_4859_a2cc_05756a62a87a</id>
-      <datasource>/geodata/ch.swisstopo.lk25.farbig_relief/lk25_farbig_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk500_masked_farbig_relief_0d96cfb8_4ecb_4d9b_8496_1d31648bb913</id>
+      <datasource>/geodata/ch.swisstopo.lk500.farbig_relief/ch.swisstopo.lk500-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk25.farbig_relief</layername>
+      <layername>ch.swisstopo.lk500-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -809,7 +1438,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -818,11 +1447,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -841,145 +1470,130 @@
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="243,166,178,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="243,166,178,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="4">
-          <rasterTransparency/>
-          <minMaxOrigin>
-            <limits>None</limits>
-            <extent>WholeRaster</extent>
-            <statAccuracy>Estimated</statAccuracy>
-            <cumulativeCutLower>0.02</cumulativeCutLower>
-            <cumulativeCutUpper>0.98</cumulativeCutUpper>
-            <stdDevFactor>2</stdDevFactor>
-          </minMaxOrigin>
-        </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
-        <resamplingStage>resamplingFilter</resamplingStage>
-      </pipe>
-      <blendMode>0</blendMode>
-    </maplayer>
-    <maplayer maxScale="18000" hasScaleBasedVisibilityFlag="1" minScale="35000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
-      <extent>
-        <xmin>2585000</xmin>
-        <ymin>1206000</ymin>
-        <xmax>2655000</xmax>
-        <ymax>1278000</ymax>
-      </extent>
-      <id>lk50_farbig_relief_20181de5_d161_4c7e_a4c6_52d9d27c536c</id>
-      <datasource>/geodata/ch.swisstopo.lk50.farbig_relief/lk50_farbig_relief.vrt</datasource>
-      <keywordList>
-        <value></value>
-      </keywordList>
-      <layername>ch.swisstopo.lk50.farbig_relief</layername>
-      <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
-          <srsid>47</srsid>
-          <srid>2056</srid>
-          <authid>EPSG:2056</authid>
-          <description>CH1903+ / LV95</description>
-          <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
-          <geographicflag>false</geographicflag>
-        </spatialrefsys>
-      </srs>
-      <resourceMetadata>
-        <identifier></identifier>
-        <parentidentifier></parentidentifier>
-        <language></language>
-        <type></type>
-        <title></title>
-        <abstract></abstract>
-        <contact>
-          <name></name>
-          <organization></organization>
-          <position></position>
-          <voice></voice>
-          <fax></fax>
-          <email></email>
-          <role></role>
-        </contact>
-        <links/>
-        <fees></fees>
-        <encoding></encoding>
-        <crs>
-          <spatialrefsys>
-            <wkt></wkt>
-            <proj4></proj4>
-            <srsid>0</srsid>
-            <srid>0</srid>
-            <authid></authid>
-            <description></description>
-            <projectionacronym></projectionacronym>
-            <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
-          </spatialrefsys>
-        </crs>
-        <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
-          <temporal>
-            <period>
-              <start></start>
-              <end></end>
-            </period>
-          </temporal>
-        </extent>
-      </resourceMetadata>
-      <provider>gdal</provider>
-      <noData>
-        <noDataList useSrcNoData="0" bandNo="1"/>
-        <noDataList useSrcNoData="0" bandNo="2"/>
-        <noDataList useSrcNoData="0" bandNo="3"/>
-        <noDataList useSrcNoData="0" bandNo="4"/>
-      </noData>
-      <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
-      </map-layer-style-manager>
-      <flags>
-        <Identifiable>1</Identifiable>
-        <Removable>1</Removable>
-        <Searchable>0</Searchable>
-      </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
-        <fixedRange>
-          <start></start>
-          <end></end>
-        </fixedRange>
-      </temporal>
-      <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
-      </customproperties>
-      <pipe>
-        <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
-        </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="4">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -989,37 +1603,58 @@
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>28</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>39</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>22</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="1e+8" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyEnabled="0" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="35000" maxScale="18000" type="raster" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyMessage="">
       <extent>
-        <xmin>2315000</xmin>
-        <ymin>913000</ymin>
-        <xmax>3059000</xmax>
-        <ymax>1415000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>maske_f7b0abd0_8125_4bbb_81ae_f7567cdfbf2f</id>
-      <datasource>/geodata/ch.so.agi.hintergrundkarte/maske.tif</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk50_masked_farbig_relief_11d41db6_2459_4aef_9d99_b8750bcdca69</id>
+      <datasource>/geodata/ch.swisstopo.lk50.farbig_relief/ch.swisstopo.lk50-masked.farbig_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>maske</layername>
+      <layername>ch.swisstopo.lk50-masked.farbig_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1043,7 +1678,7 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1052,11 +1687,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial maxy="0" maxx="0" minx="0" dimensions="2" miny="0" maxz="0" crs="" minz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1067,75 +1702,183 @@
       </resourceMetadata>
       <provider>gdal</provider>
       <noData>
-        <noDataList useSrcNoData="1" bandNo="1"/>
+        <noDataList useSrcNoData="0" bandNo="1"/>
+        <noDataList useSrcNoData="0" bandNo="2"/>
+        <noDataList useSrcNoData="0" bandNo="3"/>
+        <noDataList useSrcNoData="0" bandNo="4"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation enabled="0" band="1" zoffset="0" symbology="Line" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="line" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="255,158,23,255"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.6"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" force_rhr="0" name="" type="fill" frame_rate="10" alpha="1" is_animated="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="255,158,23,255"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0.26"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option name="WMSBackgroundLayer" type="bool" value="false"/>
+          <Option name="WMSPublishDataSourceUrl" type="bool" value="false"/>
+          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="identify/format" type="QString" value="Value"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling enabled="false" zoomedOutResamplingMethod="bilinear" maxOversampling="4" zoomedInResamplingMethod="bilinear"/>
         </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="-1">
+        <rasterrenderer greenBand="2" nodataColor="" type="multibandcolor" alphaBand="4" blueBand="3" redBand="1" opacity="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-          </colorPalette>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>254</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>253</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="2"/>
+        <brightnesscontrast brightness="0" gamma="1" contrast="0"/>
+        <huesaturation colorizeStrength="100" saturation="0" invertColors="0" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeOn="0" colorizeRed="255"/>
+        <rasterresampler zoomedOutResampler="bilinear" maxOversampling="4" zoomedInResampler="bilinear"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="krel1000_289397dd_260e_4f4c_aab0_3671a1ff8bd5"/>
-    <layer id="PK500_LV95_KREL_10L_Mosaic_2016_0d4cfbd3_ba37_4b44_87b5_b8129056b85d"/>
-    <layer id="lk200_farbig_relief_4c9d7a53_9984_4494_90d7_7dbd2608443e"/>
-    <layer id="lk100_farbig_relief_22134aeb_3970_4315_83fc_c6cbe539f7e8"/>
-    <layer id="lk50_farbig_relief_20181de5_d161_4c7e_a4c6_52d9d27c536c"/>
-    <layer id="lk25_farbig_relief_1505020c_f825_4859_a2cc_05756a62a87a"/>
-    <layer id="lk10_farbig_relief_454f9144_ef6e_42c7_adbe_67217c448956"/>
-    <layer id="maske_f7b0abd0_8125_4bbb_81ae_f7567cdfbf2f"/>
+    <layer id="ch_swisstopo_lk10_masked_farbig_relief_d70c551d_07e6_4536_98f3_071067a3327a"/>
+    <layer id="ch_swisstopo_lk25_masked_farbig_relief_85fa40e2_b8b6_4a62_bdec_ce40fafcc9df"/>
+    <layer id="ch_swisstopo_lk50_masked_farbig_relief_11d41db6_2459_4aef_9d99_b8750bcdca69"/>
+    <layer id="ch_swisstopo_lk100_masked_farbig_relief_98869cc9_398d_4df9_9624_b6073b0112ae"/>
+    <layer id="ch_swisstopo_lk200_masked_farbig_relief_1f79ce90_1af9_4b1e_aa59_ff668811f81a"/>
+    <layer id="ch_swisstopo_lk500_masked_farbig_relief_0d96cfb8_4ecb_4d9b_8496_1d31648bb913"/>
+    <layer id="ch_swisstopo_lk1000_masked_farbig_relief_9a6d25aa_790a_4712_a825_d7af03eee226"/>
   </layerorder>
   <properties>
-    <DefaultStyles>
-      <ColorRamp type="QString"></ColorRamp>
-      <Fill type="QString"></Fill>
-      <Line type="QString"></Line>
-      <Marker type="QString"></Marker>
-      <Opacity type="double">1</Opacity>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
     <Digitizing>
-      <AvoidIntersectionsMode type="int">2</AvoidIntersectionsMode>
+      <AvoidIntersectionsMode type="int">0</AvoidIntersectionsMode>
     </Digitizing>
     <Gui>
       <CanvasColorBluePart type="int">255</CanvasColorBluePart>
@@ -1153,21 +1896,18 @@
       <pythonCode type="QString"></pythonCode>
     </Macros>
     <Measure>
-      <Ellipsoid type="QString">NONE</Ellipsoid>
+      <Ellipsoid type="QString">EPSG:7004</Ellipsoid>
     </Measure>
     <Measurement>
       <AreaUnits type="QString">m2</AreaUnits>
       <DistanceUnits type="QString">meters</DistanceUnits>
     </Measurement>
     <PAL>
-      <CandidatesLine type="int">50</CandidatesLine>
       <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
-      <CandidatesPoint type="int">16</CandidatesPoint>
-      <CandidatesPolygon type="int">30</CandidatesPolygon>
       <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
       <DrawRectOnly type="bool">false</DrawRectOnly>
       <DrawUnplaced type="bool">false</DrawUnplaced>
-      <PlacementEngineVersion type="int">0</PlacementEngineVersion>
+      <PlacementEngineVersion type="int">1</PlacementEngineVersion>
       <SearchMethod type="int">0</SearchMethod>
       <ShowingAllLabels type="bool">false</ShowingAllLabels>
       <ShowingCandidates type="bool">false</ShowingCandidates>
@@ -1176,13 +1916,13 @@
       <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
     </PAL>
     <Paths>
-      <Absolute type="bool">true</Absolute>
+      <Absolute type="bool">false</Absolute>
     </Paths>
     <PositionPrecision>
       <Automatic type="bool">true</Automatic>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
     </PositionPrecision>
+    <RenderMapTile type="bool">false</RenderMapTile>
     <SpatialRefSys>
       <ProjectionsEnabled type="int">1</ProjectionsEnabled>
     </SpatialRefSys>
@@ -1198,21 +1938,21 @@
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
     <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
     <WMSContactMail type="QString"></WMSContactMail>
-    <WMSContactOrganization type="QString">AGI SO</WMSContactOrganization>
+    <WMSContactOrganization type="QString">Kanton Solothurn, Amt für Geoinformation</WMSContactOrganization>
     <WMSContactPerson type="QString"></WMSContactPerson>
     <WMSContactPhone type="QString"></WMSContactPhone>
     <WMSContactPosition type="QString"></WMSContactPosition>
     <WMSCrsList type="QStringList">
       <value>EPSG:2056</value>
-      <value>EPSG:4326</value>
     </WMSCrsList>
-    <WMSDefaultMapUnitsPerMm type="double">111319.491</WMSDefaultMapUnitsPerMm>
+    <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
     <WMSExtent type="QStringList">
       <value>2570000</value>
       <value>1208000</value>
       <value>2667000</value>
       <value>1268000</value>
     </WMSExtent>
+    <WMSFeatureInfoUseAttributeFormSettings type="bool">false</WMSFeatureInfoUseAttributeFormSettings>
     <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSImageQuality type="int">90</WMSImageQuality>
     <WMSKeywordList type="QStringList">
@@ -1225,7 +1965,7 @@
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString"></WMSServiceAbstract>
     <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
-    <WMSServiceTitle type="QString">WMS for seeding ch.so.agi.hintergrundkarte_farbig</WMSServiceTitle>
+    <WMSServiceTitle type="QString">WMS for seeding of ch.so.agi.hintergrundkarte_farbig</WMSServiceTitle>
     <WMSTileBuffer type="int">0</WMSTileBuffer>
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
@@ -1253,9 +1993,9 @@
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
     </Option>
   </dataDefinedServerProperties>
   <visibility-presets/>
@@ -1265,7 +2005,7 @@
     <parentidentifier></parentidentifier>
     <language></language>
     <type></type>
-    <title>ch.so.agi.hintergrundkarte_farbig</title>
+    <title></title>
     <abstract></abstract>
     <contact>
       <name></name>
@@ -1277,41 +2017,78 @@
       <role></role>
     </contact>
     <links/>
-    <author>AGI</author>
-    <creation>2020-06-24T15:00:21</creation>
+    <author></author>
+    <creation>2025-07-04T13:11:34</creation>
   </projectMetadata>
   <Annotations/>
   <Layouts/>
+  <mapViewDocks3D/>
   <Bookmarks/>
-  <ProjectViewSettings UseProjectScales="0">
+  <ProjectViewSettings UseProjectScales="0" rotation="0">
     <Scales/>
-    <DefaultViewExtent ymax="1258287.3656250003259629" xmin="2625955.23125000018626451" xmax="2629555.51250000018626451" ymin="1256228.3812500003259629">
-      <spatialrefsys>
-        <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-        <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+    <DefaultViewExtent ymin="1195945.12270083441399038" xmax="2699519.33712233370169997" ymax="1280088.07492942898534238" xmin="2537926.62204696470871568">
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+        <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
         <srsid>47</srsid>
         <srid>2056</srid>
         <authid>EPSG:2056</authid>
         <description>CH1903+ / LV95</description>
         <projectionacronym>somerc</projectionacronym>
-        <ellipsoidacronym>bessel</ellipsoidacronym>
+        <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h"/>
-  <ProjectDisplaySettings>
+  <ProjectStyleSettings RandomizeDefaultSymbolColor="1" DefaultSymbolOpacity="1" projectStyleId="attachment:///lhPfKV_styles.db">
+    <databases/>
+  </ProjectStyleSettings>
+  <ProjectTimeSettings cumulativeTemporalRange="0" timeStep="1" frameRate="1" timeStepUnit="h"/>
+  <ElevationProperties>
+    <terrainProvider type="flat">
+      <TerrainProvider offset="0" scale="1"/>
+    </terrainProvider>
+  </ElevationProperties>
+  <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
     <BearingFormat id="bearing">
       <Option type="Map">
-        <Option value="" name="decimal_separator" type="QChar"/>
-        <Option value="6" name="decimals" type="int"/>
-        <Option value="0" name="direction_format" type="int"/>
-        <Option value="0" name="rounding_type" type="int"/>
-        <Option value="false" name="show_plus" type="bool"/>
-        <Option value="true" name="show_thousand_separator" type="bool"/>
-        <Option value="false" name="show_trailing_zeros" type="bool"/>
-        <Option value="" name="thousand_separator" type="QChar"/>
+        <Option name="decimal_separator" type="invalid"/>
+        <Option name="decimals" type="int" value="6"/>
+        <Option name="direction_format" type="int" value="0"/>
+        <Option name="rounding_type" type="int" value="0"/>
+        <Option name="show_plus" type="bool" value="false"/>
+        <Option name="show_thousand_separator" type="bool" value="true"/>
+        <Option name="show_trailing_zeros" type="bool" value="false"/>
+        <Option name="thousand_separator" type="invalid"/>
       </Option>
     </BearingFormat>
+    <GeographicCoordinateFormat id="geographiccoordinate">
+      <Option type="Map">
+        <Option name="angle_format" type="QString" value="DecimalDegrees"/>
+        <Option name="decimal_separator" type="invalid"/>
+        <Option name="decimals" type="int" value="6"/>
+        <Option name="rounding_type" type="int" value="0"/>
+        <Option name="show_leading_degree_zeros" type="bool" value="false"/>
+        <Option name="show_leading_zeros" type="bool" value="false"/>
+        <Option name="show_plus" type="bool" value="false"/>
+        <Option name="show_suffix" type="bool" value="false"/>
+        <Option name="show_thousand_separator" type="bool" value="true"/>
+        <Option name="show_trailing_zeros" type="bool" value="false"/>
+        <Option name="thousand_separator" type="invalid"/>
+      </Option>
+    </GeographicCoordinateFormat>
+    <CoordinateCustomCrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </CoordinateCustomCrs>
   </ProjectDisplaySettings>
 </qgis>

--- a/seed/qgs/ch.so.agi.hintergrundkarte_sw.qgs
+++ b/seed/qgs/ch.so.agi.hintergrundkarte_sw.qgs
@@ -1,89 +1,115 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="ch.so.agi.hintergrundkarte_sw" saveDateTime="2023-03-23T11:11:36" saveUser="vagrant" version="3.16.3-Hannover" saveUserFull="vagrant">
+<qgis version="3.28.7-Firenze" saveDateTime="2025-07-14T14:05:51" saveUser="" saveUserFull="" projectname="">
   <homePath path=""/>
-  <title>ch.so.agi.hintergrundkarte_sw</title>
-  <autotransaction active="0"/>
-  <evaluateDefaultValues active="0"/>
-  <trust active="0"/>
+  <title></title>
+  <transaction mode="Disabled"/>
+  <projectFlags set=""/>
   <projectCrs>
-    <spatialrefsys>
-      <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-      <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+    <spatialrefsys nativeFormat="Wkt">
+      <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+      <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
       <srsid>47</srsid>
       <srid>2056</srid>
       <authid>EPSG:2056</authid>
       <description>CH1903+ / LV95</description>
       <projectionacronym>somerc</projectionacronym>
-      <ellipsoidacronym>bessel</ellipsoidacronym>
+      <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
       <geographicflag>false</geographicflag>
     </spatialrefsys>
   </projectCrs>
   <layer-tree-group>
-    <customproperties/>
-    <layer-tree-layer id="maske_f6e3da7d_dbef_4671_829f_b361337d3e44" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="maske" source="/geodata/ch.so.agi.hintergrundkarte/maske.tif" patch_size="0,0">
-      <customproperties/>
+    <customproperties>
+      <Option/>
+    </customproperties>
+    <layer-tree-group checked="Qt::Checked" groupLayer="" expanded="1" name="kantonsgrenze">
+      <customproperties>
+        <Option/>
+      </customproperties>
+      <layer-tree-layer checked="Qt::Checked" id="kantonsgrenze_generalisiert_6e83703b_0fdc_45fe_986b_017714cc1534" legend_exp="" legend_split_behavior="0" providerKey="ogr" expanded="0" name="ch.so.agi.av.hoheitsgrenzen — kantonsgrenze_generalisiert" source="/geodata/ch.so.agi.av.hoheitsgrenzen/ch.so.agi.av.hoheitsgrenzen.gpkg|layername=kantonsgrenze_generalisiert" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+      <layer-tree-layer checked="Qt::Checked" id="ch_so_agi_av_hoheitsgrenzen___kantonsgrenze_generalisiert_d0ee6c11_f9f9_474e_956b_d86f645720ce" legend_exp="" legend_split_behavior="0" providerKey="ogr" expanded="1" name="abdeckflaeche" source="/geodata/ch.so.agi.av.hoheitsgrenzen/ch.so.agi.av.hoheitsgrenzen.gpkg|layername=kantonsgrenze_generalisiert" patch_size="-1,-1">
+        <customproperties>
+          <Option/>
+        </customproperties>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk1000_masked_grau_relief_3e6eca9b_1aaa_4a1c_95c3_2944ee4206e2" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk1000-masked.grau_relief" source="/geodata/ch.swisstopo.lk1000.grau_relief/ch.swisstopo.lk1000-masked.grau_relief.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="hoheitsgrenzen_kantonsgrenze_c3fe2463_ab1d_4a5c_80be_2c8fd98c1002" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="ogr" name="hoheitsgrenzen_kantonsgrenze" source="/geodata/hoheitsgrenzen_kantonsgrenze.gpkg|layername=hoheitsgrenzen_kantonsgrenze" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk500_masked_grau_b0758e40_6ec8_486b_9882_1eaf90551462" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk500-masked.grau" source="/geodata/ch.swisstopo.lk500.grau/ch.swisstopo.lk500-masked.grau.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk1000_grau_relief_5c6cf74e_981f_4641_abfc_d74b55e6e02e" expanded="1" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk1000.grau_relief" source="/geodata/ch.swisstopo.lk1000.grau_relief/lk1000_grau_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk200_masked_grau_a274694a_01b5_4f25_90de_42e543e1b247" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk200-masked.grau" source="/geodata/ch.swisstopo.lk200.grau/ch.swisstopo.lk200-masked.grau.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="PK500_LV95_KGRS_Mosaic_2016_046ef77b_93fa_4ab5_a57d_921633c6a1c5" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk500.grau" source="/geodata/ch.swisstopo.lk500.grau/lk500_grau.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk100_masked_grau_8f483ef0_731f_4ba3_bbe2_13c604f03589" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk100-masked.grau" source="/geodata/ch.swisstopo.lk100.grau/ch.swisstopo.lk100-masked.grau.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk200_grau_e12b1615_28d6_4f6e_b42e_016d8c29cda5" expanded="0" legend_exp="" checked="Qt::Unchecked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk200.grau" source="/geodata/ch.swisstopo.lk200.grau/lk200_grau.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk50_masked_grau_d75f5663_ef7f_4968_b7ae_21b65623f0f9" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk50-masked.grau" source="/geodata/ch.swisstopo.lk50.grau/ch.swisstopo.lk50-masked.grau.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk100_grau_6c408079_3ce5_41f4_8804_ce76384d857f" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk100.grau" source="/geodata/ch.swisstopo.lk100.grau/lk100_grau.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk25_masked_grau_c84f613e_12e8_4d93_8e56_cd85bdc3d065" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk25-masked.grau" source="/geodata/ch.swisstopo.lk25.grau/ch.swisstopo.lk25-masked.grau.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer id="lk50_grau_cec4728a_148c_4f79_82cb_060463e19d71" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk50.grau" source="/geodata/ch.swisstopo.lk50.grau/lk50_grau.vrt" patch_size="0,0">
-      <customproperties/>
-    </layer-tree-layer>
-    <layer-tree-layer id="lk25_grau_eea4cf2f_880c_47c7_a6d0_af9334bc87d6" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk25.grau" source="/geodata/ch.swisstopo.lk25.grau/lk25_grau.vrt" patch_size="0,0">
-      <customproperties/>
-    </layer-tree-layer>
-    <layer-tree-layer id="lk10_grau_relief_483ec29d_51d2_4dd1_9e59_03dd92ff5981" expanded="0" legend_exp="" checked="Qt::Checked" legend_split_behavior="0" providerKey="gdal" name="ch.swisstopo.lk10.grau_relief" source="/geodata/ch.swisstopo.lk10.grau_relief/lk10_grau_relief.vrt" patch_size="0,0">
-      <customproperties/>
+    <layer-tree-layer checked="Qt::Checked" id="ch_swisstopo_lk10_masked_grau_relief_c621e4bd_2c35_490c_a66e_185d91d96663" legend_exp="" legend_split_behavior="0" providerKey="gdal" expanded="0" name="ch.swisstopo.lk10-masked.grau_relief" source="/geodata/ch.swisstopo.lk10.grau_relief/ch.swisstopo.lk10-masked.grau_relief.vrt" patch_size="-1,-1">
+      <customproperties>
+        <Option/>
+      </customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
-      <item>lk10_grau_relief_483ec29d_51d2_4dd1_9e59_03dd92ff5981</item>
-      <item>lk25_grau_eea4cf2f_880c_47c7_a6d0_af9334bc87d6</item>
-      <item>lk50_grau_cec4728a_148c_4f79_82cb_060463e19d71</item>
-      <item>lk100_grau_6c408079_3ce5_41f4_8804_ce76384d857f</item>
-      <item>lk200_grau_e12b1615_28d6_4f6e_b42e_016d8c29cda5</item>
-      <item>PK500_LV95_KGRS_Mosaic_2016_046ef77b_93fa_4ab5_a57d_921633c6a1c5</item>
-      <item>lk1000_grau_relief_5c6cf74e_981f_4641_abfc_d74b55e6e02e</item>
-      <item>maske_f6e3da7d_dbef_4671_829f_b361337d3e44</item>
-      <item>hoheitsgrenzen_kantonsgrenze_c3fe2463_ab1d_4a5c_80be_2c8fd98c1002</item>
+      <item>ch_swisstopo_lk10_masked_grau_relief_c621e4bd_2c35_490c_a66e_185d91d96663</item>
+      <item>ch_swisstopo_lk25_masked_grau_c84f613e_12e8_4d93_8e56_cd85bdc3d065</item>
+      <item>ch_swisstopo_lk50_masked_grau_d75f5663_ef7f_4968_b7ae_21b65623f0f9</item>
+      <item>ch_swisstopo_lk100_masked_grau_8f483ef0_731f_4ba3_bbe2_13c604f03589</item>
+      <item>ch_swisstopo_lk200_masked_grau_a274694a_01b5_4f25_90de_42e543e1b247</item>
+      <item>ch_swisstopo_lk500_masked_grau_b0758e40_6ec8_486b_9882_1eaf90551462</item>
+      <item>ch_swisstopo_lk1000_masked_grau_relief_3e6eca9b_1aaa_4a1c_95c3_2944ee4206e2</item>
+      <item>kantonsgrenze_generalisiert_6e83703b_0fdc_45fe_986b_017714cc1534</item>
+      <item>ch_so_agi_av_hoheitsgrenzen___kantonsgrenze_generalisiert_d0ee6c11_f9f9_474e_956b_d86f645720ce</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings maxScale="0" tolerance="12" self-snapping="0" scaleDependencyMode="0" enabled="0" minScale="0" unit="1" mode="2" type="1" intersection-snapping="0">
+  <snapping-settings scaleDependencyMode="0" minScale="0" type="1" mode="2" self-snapping="0" intersection-snapping="0" enabled="0" unit="1" tolerance="12" maxScale="0">
     <individual-layer-settings>
-      <layer-setting id="hoheitsgrenzen_kantonsgrenze_c3fe2463_ab1d_4a5c_80be_2c8fd98c1002" maxScale="0" tolerance="12" enabled="0" minScale="0" type="1" units="1"/>
+      <layer-setting minScale="0" type="1" units="1" id="kantonsgrenze_generalisiert_6e83703b_0fdc_45fe_986b_017714cc1534" enabled="0" tolerance="12" maxScale="0"/>
+      <layer-setting minScale="0" type="1" units="1" id="ch_so_agi_av_hoheitsgrenzen___kantonsgrenze_generalisiert_d0ee6c11_f9f9_474e_956b_d86f645720ce" enabled="0" tolerance="12" maxScale="0"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
+  <polymorphicRelations/>
   <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>meters</units>
     <extent>
-      <xmin>2609714.07662734901532531</xmin>
-      <ymin>1236947.77254479727707803</ymin>
-      <xmax>2611350.08357346197590232</xmax>
-      <ymax>1238069.60587927489541471</ymax>
+      <xmin>2567575</xmin>
+      <ymin>1206500</ymin>
+      <xmax>2669425</xmax>
+      <ymax>1269500</ymax>
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
-      <spatialrefsys>
-        <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-        <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+        <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
         <srsid>47</srsid>
         <srid>2056</srid>
         <authid>EPSG:2056</authid>
         <description>CH1903+ / LV95</description>
         <projectionacronym>somerc</projectionacronym>
-        <ellipsoidacronym>bessel</ellipsoidacronym>
+        <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </destinationsrs>
@@ -92,55 +118,56 @@
   </mapcanvas>
   <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="maske">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="maske_f6e3da7d_dbef_4671_829f_b361337d3e44" visible="1"/>
+    <legendgroup checked="Qt::Checked" open="true" name="kantonsgrenze">
+      <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.so.agi.av.hoheitsgrenzen — kantonsgrenze_generalisiert" showFeatureCount="0">
+        <filegroup hidden="false" open="false">
+          <legendlayerfile layerid="kantonsgrenze_generalisiert_6e83703b_0fdc_45fe_986b_017714cc1534" isInOverview="0" visible="1"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer checked="Qt::Checked" open="true" drawingOrder="-1" name="abdeckflaeche" showFeatureCount="0">
+        <filegroup hidden="false" open="true">
+          <legendlayerfile layerid="ch_so_agi_av_hoheitsgrenzen___kantonsgrenze_generalisiert_d0ee6c11_f9f9_474e_956b_d86f645720ce" isInOverview="0" visible="1"/>
+        </filegroup>
+      </legendlayer>
+    </legendgroup>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk1000-masked.grau_relief" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk1000_masked_grau_relief_3e6eca9b_1aaa_4a1c_95c3_2944ee4206e2" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="hoheitsgrenzen_kantonsgrenze">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="hoheitsgrenzen_kantonsgrenze_c3fe2463_ab1d_4a5c_80be_2c8fd98c1002" visible="1"/>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk500-masked.grau" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk500_masked_grau_b0758e40_6ec8_486b_9882_1eaf90551462" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="ch.swisstopo.lk1000.grau_relief">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk1000_grau_relief_5c6cf74e_981f_4641_abfc_d74b55e6e02e" visible="1"/>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk200-masked.grau" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk200_masked_grau_a274694a_01b5_4f25_90de_42e543e1b247" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="ch.swisstopo.lk500.grau">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="PK500_LV95_KGRS_Mosaic_2016_046ef77b_93fa_4ab5_a57d_921633c6a1c5" visible="1"/>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk100-masked.grau" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk100_masked_grau_8f483ef0_731f_4ba3_bbe2_13c604f03589" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Unchecked" open="false" name="ch.swisstopo.lk200.grau">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk200_grau_e12b1615_28d6_4f6e_b42e_016d8c29cda5" visible="0"/>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk50-masked.grau" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk50_masked_grau_d75f5663_ef7f_4968_b7ae_21b65623f0f9" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="ch.swisstopo.lk100.grau">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk100_grau_6c408079_3ce5_41f4_8804_ce76384d857f" visible="1"/>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk25-masked.grau" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk25_masked_grau_c84f613e_12e8_4d93_8e56_cd85bdc3d065" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="ch.swisstopo.lk50.grau">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk50_grau_cec4728a_148c_4f79_82cb_060463e19d71" visible="1"/>
-      </filegroup>
-    </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="ch.swisstopo.lk25.grau">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk25_grau_eea4cf2f_880c_47c7_a6d0_af9334bc87d6" visible="1"/>
-      </filegroup>
-    </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="false" name="ch.swisstopo.lk10.grau_relief">
-      <filegroup open="false" hidden="false">
-        <legendlayerfile isInOverview="0" layerid="lk10_grau_relief_483ec29d_51d2_4dd1_9e59_03dd92ff5981" visible="1"/>
+    <legendlayer checked="Qt::Checked" open="false" drawingOrder="-1" name="ch.swisstopo.lk10-masked.grau_relief" showFeatureCount="0">
+      <filegroup hidden="false" open="false">
+        <legendlayerfile layerid="ch_swisstopo_lk10_masked_grau_relief_c621e4bd_2c35_490c_a66e_185d91d96663" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
-  <mapViewDocks3D/>
-  <main-annotation-layer autoRefreshEnabled="0" type="annotation" refreshOnNotifyEnabled="0" autoRefreshTime="0" refreshOnNotifyMessage="">
+  <main-annotation-layer legendPlaceholderImage="" type="annotation" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0">
     <id>Annotations_3afc30ad_8589_459e_9d7a_f7afd4f5b89d</id>
     <datasource></datasource>
     <keywordList>
@@ -148,15 +175,15 @@
     </keywordList>
     <layername></layername>
     <srs>
-      <spatialrefsys>
-        <wkt></wkt>
-        <proj4></proj4>
-        <srsid>0</srsid>
-        <srid>0</srid>
-        <authid></authid>
-        <description></description>
-        <projectionacronym></projectionacronym>
-        <ellipsoidacronym></ellipsoidacronym>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+        <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <srsid>47</srsid>
+        <srid>2056</srid>
+        <authid>EPSG:2056</authid>
+        <description>CH1903+ / LV95</description>
+        <projectionacronym>somerc</projectionacronym>
+        <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </srs>
@@ -171,7 +198,7 @@
       <fees></fees>
       <encoding></encoding>
       <crs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt></wkt>
           <proj4></proj4>
           <srsid>0</srsid>
@@ -187,31 +214,39 @@
     </resourceMetadata>
     <items/>
     <layerOpacity>1</layerOpacity>
+    <blendMode>0</blendMode>
+    <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer maxScale="150000" hasScaleBasedVisibilityFlag="1" minScale="280000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer refreshOnNotifyMessage="" type="vector" legendPlaceholderImage="" geometry="Polygon" simplifyDrawingTol="1" wkbType="MultiPolygon" simplifyLocal="1" simplifyAlgorithm="0" autoRefreshEnabled="0" labelsEnabled="0" autoRefreshTime="0" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" minScale="10000000" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="1" maxScale="50000" symbologyReferenceScale="-1">
       <extent>
-        <xmin>2443000</xmin>
-        <ymin>1024000</ymin>
-        <xmax>2895000</xmax>
-        <ymax>1340000</ymax>
+        <xmin>2460000</xmin>
+        <ymin>1045000</ymin>
+        <xmax>2870000</xmax>
+        <ymax>1310000</ymax>
       </extent>
-      <id>PK500_LV95_KGRS_Mosaic_2016_046ef77b_93fa_4ab5_a57d_921633c6a1c5</id>
-      <datasource>/geodata/ch.swisstopo.lk500.grau/lk500_grau.vrt</datasource>
+      <wgs84extent>
+        <xmin>5.56538564062858399</xmin>
+        <ymin>45.50330242777096146</ymin>
+        <xmax>11.0493926929830053</xmax>
+        <ymax>47.94040809862327279</ymax>
+      </wgs84extent>
+      <id>ch_so_agi_av_hoheitsgrenzen___kantonsgrenze_generalisiert_d0ee6c11_f9f9_474e_956b_d86f645720ce</id>
+      <datasource>/geodata/ch.so.agi.av.hoheitsgrenzen/ch.so.agi.av.hoheitsgrenzen.gpkg|layername=kantonsgrenze_generalisiert</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk500.grau</layername>
+      <layername>abdeckflaeche</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -219,7 +254,7 @@
         <identifier></identifier>
         <parentidentifier></parentidentifier>
         <language></language>
-        <type></type>
+        <type>dataset</type>
         <title></title>
         <abstract></abstract>
         <contact>
@@ -235,20 +270,20 @@
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
-            <wkt></wkt>
-            <proj4></proj4>
-            <srsid>0</srsid>
-            <srid>0</srid>
-            <authid></authid>
-            <description></description>
-            <projectionacronym></projectionacronym>
-            <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+            <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+            <srsid>47</srsid>
+            <srid>2056</srid>
+            <authid>EPSG:2056</authid>
+            <description>CH1903+ / LV95</description>
+            <projectionacronym>somerc</projectionacronym>
+            <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="EPSG:2056" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -256,363 +291,6 @@
             </period>
           </temporal>
         </extent>
-      </resourceMetadata>
-      <provider>gdal</provider>
-      <noData>
-        <noDataList useSrcNoData="0" bandNo="1"/>
-        <noDataList useSrcNoData="0" bandNo="2"/>
-      </noData>
-      <map-layer-style-manager current="default">
-        <map-layer-style name="default"/>
-      </map-layer-style-manager>
-      <flags>
-        <Identifiable>1</Identifiable>
-        <Removable>1</Removable>
-        <Searchable>0</Searchable>
-      </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
-        <fixedRange>
-          <start></start>
-          <end></end>
-        </fixedRange>
-      </temporal>
-      <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
-      </customproperties>
-      <pipe>
-        <provider>
-          <resampling maxOversampling="4" zoomedOutResamplingMethod="bilinear" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
-        </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="2">
-          <rasterTransparency/>
-          <minMaxOrigin>
-            <limits>None</limits>
-            <extent>WholeRaster</extent>
-            <statAccuracy>Estimated</statAccuracy>
-            <cumulativeCutLower>0.02</cumulativeCutLower>
-            <cumulativeCutUpper>0.98</cumulativeCutUpper>
-            <stdDevFactor>2</stdDevFactor>
-          </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="0" label="0" color="#000000"/>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-            <paletteEntry alpha="255" value="2" label="2" color="#e7e7e7"/>
-            <paletteEntry alpha="255" value="3" label="3" color="#d3d3d3"/>
-            <paletteEntry alpha="255" value="4" label="4" color="#bebebe"/>
-            <paletteEntry alpha="255" value="5" label="5" color="#d1d1d1"/>
-            <paletteEntry alpha="255" value="6" label="6" color="#c7c7c7"/>
-            <paletteEntry alpha="255" value="7" label="7" color="#b3b3b4"/>
-            <paletteEntry alpha="255" value="8" label="8" color="#feffff"/>
-            <paletteEntry alpha="255" value="9" label="9" color="#fffefe"/>
-            <paletteEntry alpha="255" value="10" label="10" color="#fefffe"/>
-            <paletteEntry alpha="255" value="11" label="11" color="#8a8a8a"/>
-            <paletteEntry alpha="255" value="12" label="12" color="#fcfcfc"/>
-            <paletteEntry alpha="255" value="13" label="13" color="#646464"/>
-            <paletteEntry alpha="255" value="14" label="14" color="#5e5e5e"/>
-            <paletteEntry alpha="255" value="15" label="15" color="#020000"/>
-            <paletteEntry alpha="255" value="16" label="16" color="#000001"/>
-            <paletteEntry alpha="255" value="17" label="17" color="#010100"/>
-            <paletteEntry alpha="255" value="18" label="18" color="#010001"/>
-            <paletteEntry alpha="255" value="19" label="19" color="#000101"/>
-            <paletteEntry alpha="255" value="20" label="20" color="#010101"/>
-            <paletteEntry alpha="255" value="21" label="21" color="#000100"/>
-            <paletteEntry alpha="255" value="22" label="22" color="#969696"/>
-            <paletteEntry alpha="255" value="23" label="23" color="#969696"/>
-            <paletteEntry alpha="255" value="24" label="24" color="#969696"/>
-            <paletteEntry alpha="255" value="25" label="25" color="#969696"/>
-            <paletteEntry alpha="255" value="26" label="26" color="#969696"/>
-            <paletteEntry alpha="255" value="27" label="27" color="#969696"/>
-            <paletteEntry alpha="255" value="28" label="28" color="#969696"/>
-            <paletteEntry alpha="255" value="29" label="29" color="#969696"/>
-            <paletteEntry alpha="255" value="30" label="30" color="#969696"/>
-            <paletteEntry alpha="255" value="31" label="31" color="#969696"/>
-            <paletteEntry alpha="255" value="32" label="32" color="#969696"/>
-            <paletteEntry alpha="255" value="33" label="33" color="#969696"/>
-            <paletteEntry alpha="255" value="34" label="34" color="#969696"/>
-            <paletteEntry alpha="255" value="35" label="35" color="#969696"/>
-            <paletteEntry alpha="255" value="36" label="36" color="#969696"/>
-            <paletteEntry alpha="255" value="37" label="37" color="#969696"/>
-            <paletteEntry alpha="255" value="38" label="38" color="#969696"/>
-            <paletteEntry alpha="255" value="39" label="39" color="#969696"/>
-            <paletteEntry alpha="255" value="40" label="40" color="#969696"/>
-            <paletteEntry alpha="255" value="41" label="41" color="#969696"/>
-            <paletteEntry alpha="255" value="42" label="42" color="#969696"/>
-            <paletteEntry alpha="255" value="43" label="43" color="#969696"/>
-            <paletteEntry alpha="255" value="44" label="44" color="#969696"/>
-            <paletteEntry alpha="255" value="45" label="45" color="#969696"/>
-            <paletteEntry alpha="255" value="46" label="46" color="#969696"/>
-            <paletteEntry alpha="255" value="47" label="47" color="#969696"/>
-            <paletteEntry alpha="255" value="48" label="48" color="#969696"/>
-            <paletteEntry alpha="255" value="49" label="49" color="#969696"/>
-            <paletteEntry alpha="255" value="50" label="50" color="#969696"/>
-            <paletteEntry alpha="255" value="51" label="51" color="#969696"/>
-            <paletteEntry alpha="255" value="52" label="52" color="#969696"/>
-            <paletteEntry alpha="255" value="53" label="53" color="#969696"/>
-            <paletteEntry alpha="255" value="54" label="54" color="#969696"/>
-            <paletteEntry alpha="255" value="55" label="55" color="#969696"/>
-            <paletteEntry alpha="255" value="56" label="56" color="#969696"/>
-            <paletteEntry alpha="255" value="57" label="57" color="#969696"/>
-            <paletteEntry alpha="255" value="58" label="58" color="#969696"/>
-            <paletteEntry alpha="255" value="59" label="59" color="#969696"/>
-            <paletteEntry alpha="255" value="60" label="60" color="#969696"/>
-            <paletteEntry alpha="255" value="61" label="61" color="#969696"/>
-            <paletteEntry alpha="255" value="62" label="62" color="#969696"/>
-            <paletteEntry alpha="255" value="63" label="63" color="#969696"/>
-            <paletteEntry alpha="255" value="64" label="64" color="#969696"/>
-            <paletteEntry alpha="255" value="65" label="65" color="#969696"/>
-            <paletteEntry alpha="255" value="66" label="66" color="#969696"/>
-            <paletteEntry alpha="255" value="67" label="67" color="#969696"/>
-            <paletteEntry alpha="255" value="68" label="68" color="#969696"/>
-            <paletteEntry alpha="255" value="69" label="69" color="#969696"/>
-            <paletteEntry alpha="255" value="70" label="70" color="#969696"/>
-            <paletteEntry alpha="255" value="71" label="71" color="#969696"/>
-            <paletteEntry alpha="255" value="72" label="72" color="#969696"/>
-            <paletteEntry alpha="255" value="73" label="73" color="#969696"/>
-            <paletteEntry alpha="255" value="74" label="74" color="#969696"/>
-            <paletteEntry alpha="255" value="75" label="75" color="#969696"/>
-            <paletteEntry alpha="255" value="76" label="76" color="#969696"/>
-            <paletteEntry alpha="255" value="77" label="77" color="#969696"/>
-            <paletteEntry alpha="255" value="78" label="78" color="#969696"/>
-            <paletteEntry alpha="255" value="79" label="79" color="#969696"/>
-            <paletteEntry alpha="255" value="80" label="80" color="#969696"/>
-            <paletteEntry alpha="255" value="81" label="81" color="#969696"/>
-            <paletteEntry alpha="255" value="82" label="82" color="#969696"/>
-            <paletteEntry alpha="255" value="83" label="83" color="#969696"/>
-            <paletteEntry alpha="255" value="84" label="84" color="#969696"/>
-            <paletteEntry alpha="255" value="85" label="85" color="#969696"/>
-            <paletteEntry alpha="255" value="86" label="86" color="#969696"/>
-            <paletteEntry alpha="255" value="87" label="87" color="#969696"/>
-            <paletteEntry alpha="255" value="88" label="88" color="#969696"/>
-            <paletteEntry alpha="255" value="89" label="89" color="#969696"/>
-            <paletteEntry alpha="255" value="90" label="90" color="#969696"/>
-            <paletteEntry alpha="255" value="91" label="91" color="#969696"/>
-            <paletteEntry alpha="255" value="92" label="92" color="#969696"/>
-            <paletteEntry alpha="255" value="93" label="93" color="#969696"/>
-            <paletteEntry alpha="255" value="94" label="94" color="#969696"/>
-            <paletteEntry alpha="255" value="95" label="95" color="#969696"/>
-            <paletteEntry alpha="255" value="96" label="96" color="#969696"/>
-            <paletteEntry alpha="255" value="97" label="97" color="#969696"/>
-            <paletteEntry alpha="255" value="98" label="98" color="#969696"/>
-            <paletteEntry alpha="255" value="99" label="99" color="#969696"/>
-            <paletteEntry alpha="255" value="100" label="100" color="#969696"/>
-            <paletteEntry alpha="255" value="101" label="101" color="#969696"/>
-            <paletteEntry alpha="255" value="102" label="102" color="#969696"/>
-            <paletteEntry alpha="255" value="103" label="103" color="#969696"/>
-            <paletteEntry alpha="255" value="104" label="104" color="#969696"/>
-            <paletteEntry alpha="255" value="105" label="105" color="#969696"/>
-            <paletteEntry alpha="255" value="106" label="106" color="#969696"/>
-            <paletteEntry alpha="255" value="107" label="107" color="#969696"/>
-            <paletteEntry alpha="255" value="108" label="108" color="#969696"/>
-            <paletteEntry alpha="255" value="109" label="109" color="#969696"/>
-            <paletteEntry alpha="255" value="110" label="110" color="#969696"/>
-            <paletteEntry alpha="255" value="111" label="111" color="#969696"/>
-            <paletteEntry alpha="255" value="112" label="112" color="#969696"/>
-            <paletteEntry alpha="255" value="113" label="113" color="#969696"/>
-            <paletteEntry alpha="255" value="114" label="114" color="#969696"/>
-            <paletteEntry alpha="255" value="115" label="115" color="#969696"/>
-            <paletteEntry alpha="255" value="116" label="116" color="#969696"/>
-            <paletteEntry alpha="255" value="117" label="117" color="#969696"/>
-            <paletteEntry alpha="255" value="118" label="118" color="#969696"/>
-            <paletteEntry alpha="255" value="119" label="119" color="#969696"/>
-            <paletteEntry alpha="255" value="120" label="120" color="#969696"/>
-            <paletteEntry alpha="255" value="121" label="121" color="#969696"/>
-            <paletteEntry alpha="255" value="122" label="122" color="#969696"/>
-            <paletteEntry alpha="255" value="123" label="123" color="#969696"/>
-            <paletteEntry alpha="255" value="124" label="124" color="#969696"/>
-            <paletteEntry alpha="255" value="125" label="125" color="#969696"/>
-            <paletteEntry alpha="255" value="126" label="126" color="#969696"/>
-            <paletteEntry alpha="255" value="127" label="127" color="#969696"/>
-            <paletteEntry alpha="255" value="128" label="128" color="#969696"/>
-            <paletteEntry alpha="255" value="129" label="129" color="#969696"/>
-            <paletteEntry alpha="255" value="130" label="130" color="#969696"/>
-            <paletteEntry alpha="255" value="131" label="131" color="#969696"/>
-            <paletteEntry alpha="255" value="132" label="132" color="#969696"/>
-            <paletteEntry alpha="255" value="133" label="133" color="#969696"/>
-            <paletteEntry alpha="255" value="134" label="134" color="#969696"/>
-            <paletteEntry alpha="255" value="135" label="135" color="#969696"/>
-            <paletteEntry alpha="255" value="136" label="136" color="#969696"/>
-            <paletteEntry alpha="255" value="137" label="137" color="#969696"/>
-            <paletteEntry alpha="255" value="138" label="138" color="#969696"/>
-            <paletteEntry alpha="255" value="139" label="139" color="#969696"/>
-            <paletteEntry alpha="255" value="140" label="140" color="#969696"/>
-            <paletteEntry alpha="255" value="141" label="141" color="#969696"/>
-            <paletteEntry alpha="255" value="142" label="142" color="#969696"/>
-            <paletteEntry alpha="255" value="143" label="143" color="#969696"/>
-            <paletteEntry alpha="255" value="144" label="144" color="#969696"/>
-            <paletteEntry alpha="255" value="145" label="145" color="#969696"/>
-            <paletteEntry alpha="255" value="146" label="146" color="#969696"/>
-            <paletteEntry alpha="255" value="147" label="147" color="#969696"/>
-            <paletteEntry alpha="255" value="148" label="148" color="#969696"/>
-            <paletteEntry alpha="255" value="149" label="149" color="#969696"/>
-            <paletteEntry alpha="255" value="150" label="150" color="#969696"/>
-            <paletteEntry alpha="255" value="151" label="151" color="#969696"/>
-            <paletteEntry alpha="255" value="152" label="152" color="#969696"/>
-            <paletteEntry alpha="255" value="153" label="153" color="#969696"/>
-            <paletteEntry alpha="255" value="154" label="154" color="#969696"/>
-            <paletteEntry alpha="255" value="155" label="155" color="#969696"/>
-            <paletteEntry alpha="255" value="156" label="156" color="#969696"/>
-            <paletteEntry alpha="255" value="157" label="157" color="#969696"/>
-            <paletteEntry alpha="255" value="158" label="158" color="#969696"/>
-            <paletteEntry alpha="255" value="159" label="159" color="#969696"/>
-            <paletteEntry alpha="255" value="160" label="160" color="#969696"/>
-            <paletteEntry alpha="255" value="161" label="161" color="#969696"/>
-            <paletteEntry alpha="255" value="162" label="162" color="#969696"/>
-            <paletteEntry alpha="255" value="163" label="163" color="#969696"/>
-            <paletteEntry alpha="255" value="164" label="164" color="#969696"/>
-            <paletteEntry alpha="255" value="165" label="165" color="#969696"/>
-            <paletteEntry alpha="255" value="166" label="166" color="#969696"/>
-            <paletteEntry alpha="255" value="167" label="167" color="#969696"/>
-            <paletteEntry alpha="255" value="168" label="168" color="#969696"/>
-            <paletteEntry alpha="255" value="169" label="169" color="#969696"/>
-            <paletteEntry alpha="255" value="170" label="170" color="#969696"/>
-            <paletteEntry alpha="255" value="171" label="171" color="#969696"/>
-            <paletteEntry alpha="255" value="172" label="172" color="#969696"/>
-            <paletteEntry alpha="255" value="173" label="173" color="#969696"/>
-            <paletteEntry alpha="255" value="174" label="174" color="#969696"/>
-            <paletteEntry alpha="255" value="175" label="175" color="#969696"/>
-            <paletteEntry alpha="255" value="176" label="176" color="#969696"/>
-            <paletteEntry alpha="255" value="177" label="177" color="#969696"/>
-            <paletteEntry alpha="255" value="178" label="178" color="#969696"/>
-            <paletteEntry alpha="255" value="179" label="179" color="#969696"/>
-            <paletteEntry alpha="255" value="180" label="180" color="#969696"/>
-            <paletteEntry alpha="255" value="181" label="181" color="#969696"/>
-            <paletteEntry alpha="255" value="182" label="182" color="#969696"/>
-            <paletteEntry alpha="255" value="183" label="183" color="#969696"/>
-            <paletteEntry alpha="255" value="184" label="184" color="#969696"/>
-            <paletteEntry alpha="255" value="185" label="185" color="#969696"/>
-            <paletteEntry alpha="255" value="186" label="186" color="#969696"/>
-            <paletteEntry alpha="255" value="187" label="187" color="#969696"/>
-            <paletteEntry alpha="255" value="188" label="188" color="#969696"/>
-            <paletteEntry alpha="255" value="189" label="189" color="#969696"/>
-            <paletteEntry alpha="255" value="190" label="190" color="#969696"/>
-            <paletteEntry alpha="255" value="191" label="191" color="#969696"/>
-            <paletteEntry alpha="255" value="192" label="192" color="#969696"/>
-            <paletteEntry alpha="255" value="193" label="193" color="#969696"/>
-            <paletteEntry alpha="255" value="194" label="194" color="#969696"/>
-            <paletteEntry alpha="255" value="195" label="195" color="#969696"/>
-            <paletteEntry alpha="255" value="196" label="196" color="#969696"/>
-            <paletteEntry alpha="255" value="197" label="197" color="#969696"/>
-            <paletteEntry alpha="255" value="198" label="198" color="#969696"/>
-            <paletteEntry alpha="255" value="199" label="199" color="#969696"/>
-            <paletteEntry alpha="255" value="200" label="200" color="#969696"/>
-            <paletteEntry alpha="255" value="201" label="201" color="#969696"/>
-            <paletteEntry alpha="255" value="202" label="202" color="#969696"/>
-            <paletteEntry alpha="255" value="203" label="203" color="#969696"/>
-            <paletteEntry alpha="255" value="204" label="204" color="#969696"/>
-            <paletteEntry alpha="255" value="205" label="205" color="#969696"/>
-            <paletteEntry alpha="255" value="206" label="206" color="#969696"/>
-            <paletteEntry alpha="255" value="207" label="207" color="#969696"/>
-            <paletteEntry alpha="255" value="208" label="208" color="#969696"/>
-            <paletteEntry alpha="255" value="209" label="209" color="#969696"/>
-            <paletteEntry alpha="255" value="210" label="210" color="#969696"/>
-            <paletteEntry alpha="255" value="211" label="211" color="#969696"/>
-            <paletteEntry alpha="255" value="212" label="212" color="#969696"/>
-            <paletteEntry alpha="255" value="213" label="213" color="#969696"/>
-            <paletteEntry alpha="255" value="214" label="214" color="#969696"/>
-            <paletteEntry alpha="255" value="215" label="215" color="#969696"/>
-            <paletteEntry alpha="255" value="216" label="216" color="#969696"/>
-            <paletteEntry alpha="255" value="217" label="217" color="#969696"/>
-            <paletteEntry alpha="255" value="218" label="218" color="#969696"/>
-            <paletteEntry alpha="255" value="219" label="219" color="#969696"/>
-            <paletteEntry alpha="255" value="220" label="220" color="#969696"/>
-            <paletteEntry alpha="255" value="221" label="221" color="#969696"/>
-            <paletteEntry alpha="255" value="222" label="222" color="#969696"/>
-            <paletteEntry alpha="255" value="223" label="223" color="#969696"/>
-            <paletteEntry alpha="255" value="224" label="224" color="#969696"/>
-            <paletteEntry alpha="255" value="225" label="225" color="#969696"/>
-            <paletteEntry alpha="255" value="226" label="226" color="#969696"/>
-            <paletteEntry alpha="255" value="227" label="227" color="#969696"/>
-            <paletteEntry alpha="255" value="228" label="228" color="#969696"/>
-            <paletteEntry alpha="255" value="229" label="229" color="#969696"/>
-            <paletteEntry alpha="255" value="230" label="230" color="#969696"/>
-            <paletteEntry alpha="255" value="231" label="231" color="#969696"/>
-            <paletteEntry alpha="255" value="232" label="232" color="#969696"/>
-            <paletteEntry alpha="255" value="233" label="233" color="#969696"/>
-            <paletteEntry alpha="255" value="234" label="234" color="#969696"/>
-            <paletteEntry alpha="255" value="235" label="235" color="#969696"/>
-            <paletteEntry alpha="255" value="236" label="236" color="#969696"/>
-            <paletteEntry alpha="255" value="237" label="237" color="#969696"/>
-            <paletteEntry alpha="255" value="238" label="238" color="#969696"/>
-            <paletteEntry alpha="255" value="239" label="239" color="#969696"/>
-            <paletteEntry alpha="255" value="240" label="240" color="#969696"/>
-            <paletteEntry alpha="255" value="241" label="241" color="#969696"/>
-            <paletteEntry alpha="255" value="242" label="242" color="#969696"/>
-            <paletteEntry alpha="255" value="243" label="243" color="#969696"/>
-            <paletteEntry alpha="255" value="244" label="244" color="#969696"/>
-            <paletteEntry alpha="255" value="245" label="245" color="#969696"/>
-            <paletteEntry alpha="255" value="246" label="246" color="#969696"/>
-            <paletteEntry alpha="255" value="247" label="247" color="#969696"/>
-            <paletteEntry alpha="255" value="248" label="248" color="#969696"/>
-            <paletteEntry alpha="255" value="249" label="249" color="#969696"/>
-            <paletteEntry alpha="255" value="250" label="250" color="#969696"/>
-            <paletteEntry alpha="255" value="251" label="251" color="#969696"/>
-            <paletteEntry alpha="255" value="252" label="252" color="#969696"/>
-            <paletteEntry alpha="255" value="253" label="253" color="#969696"/>
-            <paletteEntry alpha="255" value="254" label="254" color="#969696"/>
-            <paletteEntry alpha="255" value="255" label="255" color="#ffffff"/>
-          </colorPalette>
-          <colorramp name="[source]" type="randomcolors"/>
-        </rasterrenderer>
-        <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
-        <resamplingStage>resamplingFilter</resamplingStage>
-      </pipe>
-      <blendMode>0</blendMode>
-    </maplayer>
-    <maplayer type="vector" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" autoRefreshTime="0" simplifyDrawingTol="1" simplifyMaxScale="1" maxScale="0" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" autoRefreshEnabled="0" simplifyLocal="1" simplifyDrawingHints="1" minScale="100000000" wkbType="MultiPolygon" geometry="Polygon" styleCategories="AllStyleCategories" readOnly="0">
-      <extent>
-        <xmin>2592560.5</xmin>
-        <ymin>1213703</ymin>
-        <xmax>2644759.75</xmax>
-        <ymax>1261330.375</ymax>
-      </extent>
-      <id>hoheitsgrenzen_kantonsgrenze_c3fe2463_ab1d_4a5c_80be_2c8fd98c1002</id>
-      <datasource>/geodata/hoheitsgrenzen_kantonsgrenze.gpkg|layername=hoheitsgrenzen_kantonsgrenze</datasource>
-      <keywordList>
-        <value></value>
-      </keywordList>
-      <layername>hoheitsgrenzen_kantonsgrenze</layername>
-      <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
-          <srsid>47</srsid>
-          <srid>2056</srid>
-          <authid>EPSG:2056</authid>
-          <description>CH1903+ / LV95</description>
-          <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
-          <geographicflag>false</geographicflag>
-        </spatialrefsys>
-      </srs>
-      <resourceMetadata>
-        <identifier></identifier>
-        <parentidentifier></parentidentifier>
-        <language></language>
-        <type>dataset</type>
-        <title></title>
-        <abstract></abstract>
-        <links/>
-        <fees></fees>
-        <encoding></encoding>
-        <crs>
-          <spatialrefsys>
-            <wkt></wkt>
-            <proj4></proj4>
-            <srsid>0</srsid>
-            <srid>0</srid>
-            <authid></authid>
-            <description></description>
-            <projectionacronym></projectionacronym>
-            <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
-          </spatialrefsys>
-        </crs>
-        <extent/>
       </resourceMetadata>
       <provider encoding="UTF-8">ogr</provider>
       <vectorjoins/>
@@ -623,192 +301,269 @@
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal startField="" endExpression="" durationUnit="min" enabled="0" endField="" fixedDuration="0" mode="0" durationField="" accumulate="0" startExpression="">
+      <temporal endExpression="" mode="0" endField="" durationField="" accumulate="0" startExpression="" fixedDuration="0" startField="" enabled="0" limitMode="0" durationUnit="min">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <renderer-v2 enableorderby="0" type="invertedPolygonRenderer" preprocessing="0" forceraster="0">
-        <renderer-v2 symbollevels="0" enableorderby="0" type="RuleRenderer" forceraster="0">
-          <rules key="{de2768ff-ea4d-4503-aa80-b67d67c9d8b4}">
-            <rule symbol="0" scalemaxdenom="1000000" key="{76d24b68-698d-427c-ad8a-7b7ff8b037f3}" scalemindenom="50000"/>
-            <rule symbol="1" scalemaxdenom="100000000" key="{367d8915-7ef8-4ed7-8709-a55518081257}" scalemindenom="1000000"/>
-          </rules>
-          <symbols>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
-              <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-                <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="color" v="255,255,255,128"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="0,0,0,255"/>
-                <prop k="outline_style" v="no"/>
-                <prop k="outline_width" v="0.26"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="style" v="solid"/>
+      <elevation zoffset="0" symbology="Line" type="IndividualFeatures" respectLayerSymbol="1" clamping="Terrain" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" zscale="1" binding="Centroid">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="232,113,141,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="232,113,141,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="166,81,101,255" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol is_animated="0" alpha="1" type="marker" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="232,113,141,255" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="diamond" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="166,81,101,255" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="3" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" type="singleSymbol" enableorderby="0" referencescale="-1" symbollevels="0">
+        <symbols>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="GeometryGenerator" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="Fill" name="SymbolType"/>
+                <Option type="QString" value="difference( layer_property( 'ch.swisstopo.lk1000-masked.grau_relief', 'extent' ), $geometry)" name="geometryModifier"/>
+                <Option type="QString" value="MapUnit" name="units"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="@0@0">
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option type="QString" value="" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
-              </layer>
-              <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-                <prop k="align_dash_pattern" v="0"/>
-                <prop k="capstyle" v="square"/>
-                <prop k="customdash" v="5;2"/>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="customdash_unit" v="MM"/>
-                <prop k="dash_pattern_offset" v="0"/>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="dash_pattern_offset_unit" v="MM"/>
-                <prop k="draw_inside_polygon" v="1"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="line_color" v="253,191,111,128"/>
-                <prop k="line_style" v="solid"/>
-                <prop k="line_width" v="4"/>
-                <prop k="line_width_unit" v="MM"/>
-                <prop k="offset" v="0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="ring_filter" v="0"/>
-                <prop k="tweak_dash_pattern_on_corners" v="0"/>
-                <prop k="use_custom_dash" v="0"/>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <data_defined_properties>
+                <layer class="SimpleFill" locked="0" pass="0" enabled="1">
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
-                    <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                    <Option type="QString" value="255,255,255,128" name="color"/>
+                    <Option type="QString" value="bevel" name="joinstyle"/>
+                    <Option type="QString" value="0,0" name="offset"/>
+                    <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                    <Option type="QString" value="MM" name="offset_unit"/>
+                    <Option type="QString" value="0,0,0,255" name="outline_color"/>
+                    <Option type="QString" value="no" name="outline_style"/>
+                    <Option type="QString" value="0.26" name="outline_width"/>
+                    <Option type="QString" value="MM" name="outline_width_unit"/>
+                    <Option type="QString" value="solid" name="style"/>
                   </Option>
-                </data_defined_properties>
-              </layer>
-              <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-                <prop k="align_dash_pattern" v="0"/>
-                <prop k="capstyle" v="square"/>
-                <prop k="customdash" v="5;2"/>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="customdash_unit" v="MM"/>
-                <prop k="dash_pattern_offset" v="0"/>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="dash_pattern_offset_unit" v="MM"/>
-                <prop k="draw_inside_polygon" v="0"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="line_color" v="255,127,0,255"/>
-                <prop k="line_style" v="solid"/>
-                <prop k="line_width" v="0.26"/>
-                <prop k="line_width_unit" v="MM"/>
-                <prop k="offset" v="0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="ring_filter" v="0"/>
-                <prop k="tweak_dash_pattern_on_corners" v="0"/>
-                <prop k="use_custom_dash" v="0"/>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <data_defined_properties>
-                  <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
-                    <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
-                  </Option>
-                </data_defined_properties>
-              </layer>
-            </symbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="1" type="fill">
-              <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-                <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="color" v="255,255,255,128"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="0,0,0,255"/>
-                <prop k="outline_style" v="no"/>
-                <prop k="outline_width" v="0.26"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="style" v="solid"/>
-                <data_defined_properties>
-                  <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
-                    <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
-                  </Option>
-                </data_defined_properties>
-              </layer>
-              <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-                <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="color" v="255,127,0,255"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="offset" v="0,0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="outline_color" v="255,127,0,255"/>
-                <prop k="outline_style" v="solid"/>
-                <prop k="outline_width" v="0.26"/>
-                <prop k="outline_width_unit" v="MM"/>
-                <prop k="style" v="no"/>
-                <data_defined_properties>
-                  <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
-                    <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
-                  </Option>
-                </data_defined_properties>
-              </layer>
-            </symbol>
-          </symbols>
-        </renderer-v2>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option type="QString" value="" name="name"/>
+                      <Option name="properties"/>
+                      <Option type="QString" value="collection" name="type"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property key="variableNames"/>
-        <property key="variableValues"/>
+        <Option type="Map">
+          <Option type="QString" value="0" name="embeddedWidgets/count"/>
+          <Option name="variableNames"/>
+          <Option name="variableValues"/>
+        </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory spacing="0" penAlpha="255" penWidth="0" maxScaleDenominator="1e+8" backgroundAlpha="255" direction="1" penColor="#000000" scaleDependency="Area" opacity="1" rotationOffset="270" labelPlacementMethod="XHeight" diagramOrientation="Up" sizeScale="3x:0,0,0,0,0,0" spacingUnitScale="3x:0,0,0,0,0,0" spacingUnit="MM" lineSizeType="MM" minimumSize="0" enabled="0" sizeType="MM" showAxis="0" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" lineSizeScale="3x:0,0,0,0,0,0" height="15" minScaleDenominator="0" barWidth="5">
-          <fontProperties description="Noto Sans,10,-1,0,50,0,0,0,0,0,Regular" style="Regular"/>
-          <attribute label="" color="#000000" field=""/>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory diagramOrientation="Up" labelPlacementMethod="XHeight" minScaleDenominator="1" minimumSize="0" width="15" backgroundAlpha="255" showAxis="0" backgroundColor="#ffffff" height="15" direction="1" penColor="#000000" scaleBasedVisibility="0" barWidth="5" lineSizeScale="3x:0,0,0,0,0,0" spacingUnit="MM" scaleDependency="Area" sizeType="MM" lineSizeType="MM" spacingUnitScale="3x:0,0,0,0,0,0" sizeScale="3x:0,0,0,0,0,0" penWidth="0" enabled="0" opacity="1" spacing="0" penAlpha="255" maxScaleDenominator="1e+08" rotationOffset="270">
+          <fontProperties description="Sans Serif,9,-1,5,50,0,0,0,0,0" strikethrough="0" italic="0" underline="0" bold="0" style=""/>
+          <attribute label="" color="#000000" colorOpacity="1" field=""/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
-              <layer enabled="1" locked="0" class="SimpleLine" pass="0">
-                <prop k="align_dash_pattern" v="0"/>
-                <prop k="capstyle" v="square"/>
-                <prop k="customdash" v="5;2"/>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="customdash_unit" v="MM"/>
-                <prop k="dash_pattern_offset" v="0"/>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="dash_pattern_offset_unit" v="MM"/>
-                <prop k="draw_inside_polygon" v="0"/>
-                <prop k="joinstyle" v="bevel"/>
-                <prop k="line_color" v="35,35,35,255"/>
-                <prop k="line_style" v="solid"/>
-                <prop k="line_width" v="0.26"/>
-                <prop k="line_width_unit" v="MM"/>
-                <prop k="offset" v="0"/>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-                <prop k="offset_unit" v="MM"/>
-                <prop k="ring_filter" v="0"/>
-                <prop k="tweak_dash_pattern_on_corners" v="0"/>
-                <prop k="use_custom_dash" v="0"/>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+                <Option type="Map">
+                  <Option type="QString" value="0" name="align_dash_pattern"/>
+                  <Option type="QString" value="square" name="capstyle"/>
+                  <Option type="QString" value="5;2" name="customdash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="customdash_unit"/>
+                  <Option type="QString" value="0" name="dash_pattern_offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                  <Option type="QString" value="0" name="draw_inside_polygon"/>
+                  <Option type="QString" value="bevel" name="joinstyle"/>
+                  <Option type="QString" value="35,35,35,255" name="line_color"/>
+                  <Option type="QString" value="solid" name="line_style"/>
+                  <Option type="QString" value="0.26" name="line_width"/>
+                  <Option type="QString" value="MM" name="line_width_unit"/>
+                  <Option type="QString" value="0" name="offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="offset_unit"/>
+                  <Option type="QString" value="0" name="ring_filter"/>
+                  <Option type="QString" value="0" name="trim_distance_end"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                  <Option type="QString" value="0" name="trim_distance_start"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                  <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                  <Option type="QString" value="0" name="use_custom_dash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option value="" name="name" type="QString"/>
+                    <Option type="QString" value="" name="name"/>
                     <Option name="properties"/>
-                    <Option value="collection" name="type" type="QString"/>
+                    <Option type="QString" value="collection" name="type"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -816,36 +571,36 @@
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings linePlacementFlags="18" zIndex="0" priority="0" dist="0" showAll="1" placement="1" obstacle="0">
+      <DiagramLayerSettings zIndex="0" obstacle="0" placement="0" priority="0" dist="0" showAll="1" linePlacementFlags="2">
         <properties>
           <Option type="Map">
-            <Option value="" name="name" type="QString"/>
+            <Option type="QString" value="" name="name"/>
             <Option name="properties"/>
-            <Option value="collection" name="type" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
         <activeChecks/>
         <checkConfiguration type="Map">
-          <Option name="QgsGeometryGapCheck" type="Map">
-            <Option value="0" name="allowedGapsBuffer" type="double"/>
-            <Option value="false" name="allowedGapsEnabled" type="bool"/>
-            <Option value="" name="allowedGapsLayer" type="QString"/>
+          <Option type="Map" name="QgsGeometryGapCheck">
+            <Option type="double" value="0" name="allowedGapsBuffer"/>
+            <Option type="bool" value="false" name="allowedGapsEnabled"/>
+            <Option type="QString" value="" name="allowedGapsLayer"/>
           </Option>
         </checkConfiguration>
       </geometryOptions>
-      <legend type="default-vector"/>
+      <legend type="default-vector" showLabelLegend="0"/>
       <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="t_id">
+        <field configurationFlags="None" name="T_Id">
           <editWidget type="TextEdit">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="t_ili_tid">
+        <field configurationFlags="None" name="T_Ili_Tid">
           <editWidget type="TextEdit">
             <config>
               <Option/>
@@ -875,46 +630,45 @@
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias index="0" name="" field="t_id"/>
-        <alias index="1" name="" field="t_ili_tid"/>
+        <alias index="0" name="" field="T_Id"/>
+        <alias index="1" name="" field="T_Ili_Tid"/>
         <alias index="2" name="" field="kantonsname"/>
         <alias index="3" name="" field="kantonskuerzel"/>
         <alias index="4" name="" field="kantonsnummer"/>
       </aliases>
       <defaults>
-        <default applyOnUpdate="0" field="t_id" expression=""/>
-        <default applyOnUpdate="0" field="t_ili_tid" expression=""/>
-        <default applyOnUpdate="0" field="kantonsname" expression=""/>
-        <default applyOnUpdate="0" field="kantonskuerzel" expression=""/>
-        <default applyOnUpdate="0" field="kantonsnummer" expression=""/>
+        <default applyOnUpdate="0" expression="" field="T_Id"/>
+        <default applyOnUpdate="0" expression="" field="T_Ili_Tid"/>
+        <default applyOnUpdate="0" expression="" field="kantonsname"/>
+        <default applyOnUpdate="0" expression="" field="kantonskuerzel"/>
+        <default applyOnUpdate="0" expression="" field="kantonsnummer"/>
       </defaults>
       <constraints>
-        <constraint exp_strength="0" unique_strength="1" constraints="3" field="t_id" notnull_strength="1"/>
-        <constraint exp_strength="0" unique_strength="0" constraints="0" field="t_ili_tid" notnull_strength="0"/>
-        <constraint exp_strength="0" unique_strength="0" constraints="1" field="kantonsname" notnull_strength="1"/>
-        <constraint exp_strength="0" unique_strength="0" constraints="1" field="kantonskuerzel" notnull_strength="1"/>
-        <constraint exp_strength="0" unique_strength="0" constraints="1" field="kantonsnummer" notnull_strength="1"/>
+        <constraint constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1" field="T_Id"/>
+        <constraint constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0" field="T_Ili_Tid"/>
+        <constraint constraints="1" exp_strength="0" unique_strength="0" notnull_strength="1" field="kantonsname"/>
+        <constraint constraints="1" exp_strength="0" unique_strength="0" notnull_strength="1" field="kantonskuerzel"/>
+        <constraint constraints="1" exp_strength="0" unique_strength="0" notnull_strength="1" field="kantonsnummer"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="t_id" desc=""/>
-        <constraint exp="" field="t_ili_tid" desc=""/>
-        <constraint exp="" field="kantonsname" desc=""/>
-        <constraint exp="" field="kantonskuerzel" desc=""/>
-        <constraint exp="" field="kantonsnummer" desc=""/>
+        <constraint exp="" desc="" field="T_Id"/>
+        <constraint exp="" desc="" field="T_Ili_Tid"/>
+        <constraint exp="" desc="" field="kantonsname"/>
+        <constraint exp="" desc="" field="kantonskuerzel"/>
+        <constraint exp="" desc="" field="kantonsnummer"/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortExpression="" sortOrder="0" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column hidden="0" name="fid" width="-1" type="field"/>
-          <column hidden="0" name="t_id" width="-1" type="field"/>
-          <column hidden="0" name="t_ili_tid" width="-1" type="field"/>
-          <column hidden="0" name="kantonsname" width="-1" type="field"/>
-          <column hidden="0" name="kantonskuerzel" width="-1" type="field"/>
-          <column hidden="0" name="kantonsnummer" width="-1" type="field"/>
-          <column hidden="1" width="-1" type="actions"/>
+          <column type="actions" hidden="1" width="-1"/>
+          <column type="field" hidden="0" width="-1" name="kantonsname"/>
+          <column type="field" hidden="0" width="-1" name="kantonskuerzel"/>
+          <column type="field" hidden="0" width="-1" name="T_Id"/>
+          <column type="field" hidden="0" width="-1" name="T_Ili_Tid"/>
+          <column type="field" hidden="0" width="-1" name="kantonsnummer"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -922,10 +676,10 @@
         <fieldstyles/>
       </conditionalstyles>
       <storedexpressions/>
-      <editform tolerant="1"></editform>
+      <editform tolerant="1">.</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
-      <editforminitfilepath></editforminitfilepath>
+      <editforminitfilepath>.</editforminitfilepath>
       <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -946,49 +700,60 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="fid"/>
+        <field editable="1" name="T_Id"/>
+        <field editable="1" name="T_Ili_Tid"/>
         <field editable="1" name="kantonskuerzel"/>
         <field editable="1" name="kantonsname"/>
         <field editable="1" name="kantonsnummer"/>
-        <field editable="1" name="t_id"/>
-        <field editable="1" name="t_ili_tid"/>
       </editable>
       <labelOnTop>
-        <field name="fid" labelOnTop="0"/>
+        <field name="T_Id" labelOnTop="0"/>
+        <field name="T_Ili_Tid" labelOnTop="0"/>
         <field name="kantonskuerzel" labelOnTop="0"/>
         <field name="kantonsname" labelOnTop="0"/>
         <field name="kantonsnummer" labelOnTop="0"/>
-        <field name="t_id" labelOnTop="0"/>
-        <field name="t_ili_tid" labelOnTop="0"/>
       </labelOnTop>
+      <reuseLastValue>
+        <field name="T_Id" reuseLastValue="0"/>
+        <field name="T_Ili_Tid" reuseLastValue="0"/>
+        <field name="kantonskuerzel" reuseLastValue="0"/>
+        <field name="kantonsname" reuseLastValue="0"/>
+        <field name="kantonsnummer" reuseLastValue="0"/>
+      </reuseLastValue>
       <dataDefinedFieldProperties/>
       <widgets/>
-      <previewExpression>kantonsname</previewExpression>
+      <previewExpression>"T_Id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer maxScale="280000" hasScaleBasedVisibilityFlag="1" minScale="1e+8" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="1e+08" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="280000">
       <extent>
-        <xmin>2317000</xmin>
-        <ymin>913000</ymin>
-        <xmax>3057000</xmax>
-        <ymax>1413000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk1000_grau_relief_5c6cf74e_981f_4641_abfc_d74b55e6e02e</id>
-      <datasource>/geodata/ch.swisstopo.lk1000.grau_relief/lk1000_grau_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk1000_masked_grau_relief_3e6eca9b_1aaa_4a1c_95c3_2944ee4206e2</id>
+      <datasource>/geodata/ch.swisstopo.lk1000.grau_relief/ch.swisstopo.lk1000-masked.grau_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk1000.grau_relief</layername>
+      <layername>ch.swisstopo.lk1000-masked.grau_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1012,7 +777,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1021,11 +786,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1044,68 +809,191 @@ def my_form_open(dialog, layer, feature):
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="255,158,23,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="255,158,23,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer redBand="1" nodataColor="" greenBand="2" blueBand="3" opacity="1" type="multibandcolor" alphaBand="4">
+        <rasterrenderer blueBand="3" type="multibandcolor" alphaBand="4" opacity="1" nodataColor="" greenBand="2" redBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="35000" hasScaleBasedVisibilityFlag="1" minScale="70000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="70000" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="35000">
       <extent>
-        <xmin>2550000</xmin>
-        <ymin>1206000</ymin>
-        <xmax>2690000</xmax>
-        <ymax>1302000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk100_grau_6c408079_3ce5_41f4_8804_ce76384d857f</id>
-      <datasource>/geodata/ch.swisstopo.lk100.grau/lk100_grau.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk100_masked_grau_8f483ef0_731f_4ba3_bbe2_13c604f03589</id>
+      <datasource>/geodata/ch.swisstopo.lk100.grau/ch.swisstopo.lk100-masked.grau.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk100.grau</layername>
+      <layername>ch.swisstopo.lk100-masked.grau</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1129,7 +1017,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1138,11 +1026,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1155,330 +1043,197 @@ def my_form_open(dialog, layer, feature):
       <noData>
         <noDataList useSrcNoData="0" bandNo="1"/>
         <noDataList useSrcNoData="0" bandNo="2"/>
+        <noDataList useSrcNoData="0" bandNo="3"/>
+        <noDataList useSrcNoData="0" bandNo="4"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="152,125,183,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="152,125,183,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="2">
+        <rasterrenderer blueBand="3" type="multibandcolor" alphaBand="4" opacity="1" nodataColor="" greenBand="2" redBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="0" label="0" color="#000000"/>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-            <paletteEntry alpha="255" value="2" label="2" color="#f4f4f4"/>
-            <paletteEntry alpha="255" value="3" label="3" color="#e7e7e7"/>
-            <paletteEntry alpha="255" value="4" label="4" color="#d3d3d3"/>
-            <paletteEntry alpha="255" value="5" label="5" color="#cacacb"/>
-            <paletteEntry alpha="255" value="6" label="6" color="#cacaca"/>
-            <paletteEntry alpha="255" value="7" label="7" color="#c5c5c5"/>
-            <paletteEntry alpha="255" value="8" label="8" color="#a7a7a7"/>
-            <paletteEntry alpha="255" value="9" label="9" color="#9e9e9e"/>
-            <paletteEntry alpha="255" value="10" label="10" color="#d1d1d1"/>
-            <paletteEntry alpha="255" value="11" label="11" color="#b3b3b4"/>
-            <paletteEntry alpha="255" value="12" label="12" color="#fffeff"/>
-            <paletteEntry alpha="255" value="13" label="13" color="#feffff"/>
-            <paletteEntry alpha="255" value="14" label="14" color="#fffefe"/>
-            <paletteEntry alpha="255" value="15" label="15" color="#fefffe"/>
-            <paletteEntry alpha="255" value="16" label="16" color="#8f8f8f"/>
-            <paletteEntry alpha="255" value="17" label="17" color="#8a8a8a"/>
-            <paletteEntry alpha="255" value="18" label="18" color="#fcfcfc"/>
-            <paletteEntry alpha="255" value="19" label="19" color="#f8f8f8"/>
-            <paletteEntry alpha="255" value="20" label="20" color="#6a6a6a"/>
-            <paletteEntry alpha="255" value="21" label="21" color="#676767"/>
-            <paletteEntry alpha="255" value="22" label="22" color="#646464"/>
-            <paletteEntry alpha="255" value="23" label="23" color="#626262"/>
-            <paletteEntry alpha="255" value="24" label="24" color="#5e5e5e"/>
-            <paletteEntry alpha="255" value="25" label="25" color="#fefeff"/>
-            <paletteEntry alpha="255" value="26" label="26" color="#000002"/>
-            <paletteEntry alpha="255" value="27" label="27" color="#010000"/>
-            <paletteEntry alpha="255" value="28" label="28" color="#000200"/>
-            <paletteEntry alpha="255" value="29" label="29" color="#020000"/>
-            <paletteEntry alpha="255" value="30" label="30" color="#000001"/>
-            <paletteEntry alpha="255" value="31" label="31" color="#010100"/>
-            <paletteEntry alpha="255" value="32" label="32" color="#010001"/>
-            <paletteEntry alpha="255" value="33" label="33" color="#000101"/>
-            <paletteEntry alpha="255" value="34" label="34" color="#969696"/>
-            <paletteEntry alpha="255" value="35" label="35" color="#969696"/>
-            <paletteEntry alpha="255" value="36" label="36" color="#969696"/>
-            <paletteEntry alpha="255" value="37" label="37" color="#969696"/>
-            <paletteEntry alpha="255" value="38" label="38" color="#969696"/>
-            <paletteEntry alpha="255" value="39" label="39" color="#969696"/>
-            <paletteEntry alpha="255" value="40" label="40" color="#969696"/>
-            <paletteEntry alpha="255" value="41" label="41" color="#969696"/>
-            <paletteEntry alpha="255" value="42" label="42" color="#969696"/>
-            <paletteEntry alpha="255" value="43" label="43" color="#969696"/>
-            <paletteEntry alpha="255" value="44" label="44" color="#969696"/>
-            <paletteEntry alpha="255" value="45" label="45" color="#969696"/>
-            <paletteEntry alpha="255" value="46" label="46" color="#969696"/>
-            <paletteEntry alpha="255" value="47" label="47" color="#969696"/>
-            <paletteEntry alpha="255" value="48" label="48" color="#969696"/>
-            <paletteEntry alpha="255" value="49" label="49" color="#969696"/>
-            <paletteEntry alpha="255" value="50" label="50" color="#969696"/>
-            <paletteEntry alpha="255" value="51" label="51" color="#969696"/>
-            <paletteEntry alpha="255" value="52" label="52" color="#969696"/>
-            <paletteEntry alpha="255" value="53" label="53" color="#969696"/>
-            <paletteEntry alpha="255" value="54" label="54" color="#969696"/>
-            <paletteEntry alpha="255" value="55" label="55" color="#969696"/>
-            <paletteEntry alpha="255" value="56" label="56" color="#969696"/>
-            <paletteEntry alpha="255" value="57" label="57" color="#969696"/>
-            <paletteEntry alpha="255" value="58" label="58" color="#969696"/>
-            <paletteEntry alpha="255" value="59" label="59" color="#969696"/>
-            <paletteEntry alpha="255" value="60" label="60" color="#969696"/>
-            <paletteEntry alpha="255" value="61" label="61" color="#969696"/>
-            <paletteEntry alpha="255" value="62" label="62" color="#969696"/>
-            <paletteEntry alpha="255" value="63" label="63" color="#969696"/>
-            <paletteEntry alpha="255" value="64" label="64" color="#969696"/>
-            <paletteEntry alpha="255" value="65" label="65" color="#969696"/>
-            <paletteEntry alpha="255" value="66" label="66" color="#969696"/>
-            <paletteEntry alpha="255" value="67" label="67" color="#969696"/>
-            <paletteEntry alpha="255" value="68" label="68" color="#969696"/>
-            <paletteEntry alpha="255" value="69" label="69" color="#969696"/>
-            <paletteEntry alpha="255" value="70" label="70" color="#969696"/>
-            <paletteEntry alpha="255" value="71" label="71" color="#969696"/>
-            <paletteEntry alpha="255" value="72" label="72" color="#969696"/>
-            <paletteEntry alpha="255" value="73" label="73" color="#969696"/>
-            <paletteEntry alpha="255" value="74" label="74" color="#969696"/>
-            <paletteEntry alpha="255" value="75" label="75" color="#969696"/>
-            <paletteEntry alpha="255" value="76" label="76" color="#969696"/>
-            <paletteEntry alpha="255" value="77" label="77" color="#969696"/>
-            <paletteEntry alpha="255" value="78" label="78" color="#969696"/>
-            <paletteEntry alpha="255" value="79" label="79" color="#969696"/>
-            <paletteEntry alpha="255" value="80" label="80" color="#969696"/>
-            <paletteEntry alpha="255" value="81" label="81" color="#969696"/>
-            <paletteEntry alpha="255" value="82" label="82" color="#969696"/>
-            <paletteEntry alpha="255" value="83" label="83" color="#969696"/>
-            <paletteEntry alpha="255" value="84" label="84" color="#969696"/>
-            <paletteEntry alpha="255" value="85" label="85" color="#969696"/>
-            <paletteEntry alpha="255" value="86" label="86" color="#969696"/>
-            <paletteEntry alpha="255" value="87" label="87" color="#969696"/>
-            <paletteEntry alpha="255" value="88" label="88" color="#969696"/>
-            <paletteEntry alpha="255" value="89" label="89" color="#969696"/>
-            <paletteEntry alpha="255" value="90" label="90" color="#969696"/>
-            <paletteEntry alpha="255" value="91" label="91" color="#969696"/>
-            <paletteEntry alpha="255" value="92" label="92" color="#969696"/>
-            <paletteEntry alpha="255" value="93" label="93" color="#969696"/>
-            <paletteEntry alpha="255" value="94" label="94" color="#969696"/>
-            <paletteEntry alpha="255" value="95" label="95" color="#969696"/>
-            <paletteEntry alpha="255" value="96" label="96" color="#969696"/>
-            <paletteEntry alpha="255" value="97" label="97" color="#969696"/>
-            <paletteEntry alpha="255" value="98" label="98" color="#969696"/>
-            <paletteEntry alpha="255" value="99" label="99" color="#969696"/>
-            <paletteEntry alpha="255" value="100" label="100" color="#969696"/>
-            <paletteEntry alpha="255" value="101" label="101" color="#969696"/>
-            <paletteEntry alpha="255" value="102" label="102" color="#969696"/>
-            <paletteEntry alpha="255" value="103" label="103" color="#969696"/>
-            <paletteEntry alpha="255" value="104" label="104" color="#969696"/>
-            <paletteEntry alpha="255" value="105" label="105" color="#969696"/>
-            <paletteEntry alpha="255" value="106" label="106" color="#969696"/>
-            <paletteEntry alpha="255" value="107" label="107" color="#969696"/>
-            <paletteEntry alpha="255" value="108" label="108" color="#969696"/>
-            <paletteEntry alpha="255" value="109" label="109" color="#969696"/>
-            <paletteEntry alpha="255" value="110" label="110" color="#969696"/>
-            <paletteEntry alpha="255" value="111" label="111" color="#969696"/>
-            <paletteEntry alpha="255" value="112" label="112" color="#969696"/>
-            <paletteEntry alpha="255" value="113" label="113" color="#969696"/>
-            <paletteEntry alpha="255" value="114" label="114" color="#969696"/>
-            <paletteEntry alpha="255" value="115" label="115" color="#969696"/>
-            <paletteEntry alpha="255" value="116" label="116" color="#969696"/>
-            <paletteEntry alpha="255" value="117" label="117" color="#969696"/>
-            <paletteEntry alpha="255" value="118" label="118" color="#969696"/>
-            <paletteEntry alpha="255" value="119" label="119" color="#969696"/>
-            <paletteEntry alpha="255" value="120" label="120" color="#969696"/>
-            <paletteEntry alpha="255" value="121" label="121" color="#969696"/>
-            <paletteEntry alpha="255" value="122" label="122" color="#969696"/>
-            <paletteEntry alpha="255" value="123" label="123" color="#969696"/>
-            <paletteEntry alpha="255" value="124" label="124" color="#969696"/>
-            <paletteEntry alpha="255" value="125" label="125" color="#969696"/>
-            <paletteEntry alpha="255" value="126" label="126" color="#969696"/>
-            <paletteEntry alpha="255" value="127" label="127" color="#969696"/>
-            <paletteEntry alpha="255" value="128" label="128" color="#969696"/>
-            <paletteEntry alpha="255" value="129" label="129" color="#969696"/>
-            <paletteEntry alpha="255" value="130" label="130" color="#969696"/>
-            <paletteEntry alpha="255" value="131" label="131" color="#969696"/>
-            <paletteEntry alpha="255" value="132" label="132" color="#969696"/>
-            <paletteEntry alpha="255" value="133" label="133" color="#969696"/>
-            <paletteEntry alpha="255" value="134" label="134" color="#969696"/>
-            <paletteEntry alpha="255" value="135" label="135" color="#969696"/>
-            <paletteEntry alpha="255" value="136" label="136" color="#969696"/>
-            <paletteEntry alpha="255" value="137" label="137" color="#969696"/>
-            <paletteEntry alpha="255" value="138" label="138" color="#969696"/>
-            <paletteEntry alpha="255" value="139" label="139" color="#969696"/>
-            <paletteEntry alpha="255" value="140" label="140" color="#969696"/>
-            <paletteEntry alpha="255" value="141" label="141" color="#969696"/>
-            <paletteEntry alpha="255" value="142" label="142" color="#969696"/>
-            <paletteEntry alpha="255" value="143" label="143" color="#969696"/>
-            <paletteEntry alpha="255" value="144" label="144" color="#969696"/>
-            <paletteEntry alpha="255" value="145" label="145" color="#969696"/>
-            <paletteEntry alpha="255" value="146" label="146" color="#969696"/>
-            <paletteEntry alpha="255" value="147" label="147" color="#969696"/>
-            <paletteEntry alpha="255" value="148" label="148" color="#969696"/>
-            <paletteEntry alpha="255" value="149" label="149" color="#969696"/>
-            <paletteEntry alpha="255" value="150" label="150" color="#969696"/>
-            <paletteEntry alpha="255" value="151" label="151" color="#969696"/>
-            <paletteEntry alpha="255" value="152" label="152" color="#969696"/>
-            <paletteEntry alpha="255" value="153" label="153" color="#969696"/>
-            <paletteEntry alpha="255" value="154" label="154" color="#969696"/>
-            <paletteEntry alpha="255" value="155" label="155" color="#969696"/>
-            <paletteEntry alpha="255" value="156" label="156" color="#969696"/>
-            <paletteEntry alpha="255" value="157" label="157" color="#969696"/>
-            <paletteEntry alpha="255" value="158" label="158" color="#969696"/>
-            <paletteEntry alpha="255" value="159" label="159" color="#969696"/>
-            <paletteEntry alpha="255" value="160" label="160" color="#969696"/>
-            <paletteEntry alpha="255" value="161" label="161" color="#969696"/>
-            <paletteEntry alpha="255" value="162" label="162" color="#969696"/>
-            <paletteEntry alpha="255" value="163" label="163" color="#969696"/>
-            <paletteEntry alpha="255" value="164" label="164" color="#969696"/>
-            <paletteEntry alpha="255" value="165" label="165" color="#969696"/>
-            <paletteEntry alpha="255" value="166" label="166" color="#969696"/>
-            <paletteEntry alpha="255" value="167" label="167" color="#969696"/>
-            <paletteEntry alpha="255" value="168" label="168" color="#969696"/>
-            <paletteEntry alpha="255" value="169" label="169" color="#969696"/>
-            <paletteEntry alpha="255" value="170" label="170" color="#969696"/>
-            <paletteEntry alpha="255" value="171" label="171" color="#969696"/>
-            <paletteEntry alpha="255" value="172" label="172" color="#969696"/>
-            <paletteEntry alpha="255" value="173" label="173" color="#969696"/>
-            <paletteEntry alpha="255" value="174" label="174" color="#969696"/>
-            <paletteEntry alpha="255" value="175" label="175" color="#969696"/>
-            <paletteEntry alpha="255" value="176" label="176" color="#969696"/>
-            <paletteEntry alpha="255" value="177" label="177" color="#969696"/>
-            <paletteEntry alpha="255" value="178" label="178" color="#969696"/>
-            <paletteEntry alpha="255" value="179" label="179" color="#969696"/>
-            <paletteEntry alpha="255" value="180" label="180" color="#969696"/>
-            <paletteEntry alpha="255" value="181" label="181" color="#969696"/>
-            <paletteEntry alpha="255" value="182" label="182" color="#969696"/>
-            <paletteEntry alpha="255" value="183" label="183" color="#969696"/>
-            <paletteEntry alpha="255" value="184" label="184" color="#969696"/>
-            <paletteEntry alpha="255" value="185" label="185" color="#969696"/>
-            <paletteEntry alpha="255" value="186" label="186" color="#969696"/>
-            <paletteEntry alpha="255" value="187" label="187" color="#969696"/>
-            <paletteEntry alpha="255" value="188" label="188" color="#969696"/>
-            <paletteEntry alpha="255" value="189" label="189" color="#969696"/>
-            <paletteEntry alpha="255" value="190" label="190" color="#969696"/>
-            <paletteEntry alpha="255" value="191" label="191" color="#969696"/>
-            <paletteEntry alpha="255" value="192" label="192" color="#969696"/>
-            <paletteEntry alpha="255" value="193" label="193" color="#969696"/>
-            <paletteEntry alpha="255" value="194" label="194" color="#969696"/>
-            <paletteEntry alpha="255" value="195" label="195" color="#969696"/>
-            <paletteEntry alpha="255" value="196" label="196" color="#969696"/>
-            <paletteEntry alpha="255" value="197" label="197" color="#969696"/>
-            <paletteEntry alpha="255" value="198" label="198" color="#969696"/>
-            <paletteEntry alpha="255" value="199" label="199" color="#969696"/>
-            <paletteEntry alpha="255" value="200" label="200" color="#969696"/>
-            <paletteEntry alpha="255" value="201" label="201" color="#969696"/>
-            <paletteEntry alpha="255" value="202" label="202" color="#969696"/>
-            <paletteEntry alpha="255" value="203" label="203" color="#969696"/>
-            <paletteEntry alpha="255" value="204" label="204" color="#969696"/>
-            <paletteEntry alpha="255" value="205" label="205" color="#969696"/>
-            <paletteEntry alpha="255" value="206" label="206" color="#969696"/>
-            <paletteEntry alpha="255" value="207" label="207" color="#969696"/>
-            <paletteEntry alpha="255" value="208" label="208" color="#969696"/>
-            <paletteEntry alpha="255" value="209" label="209" color="#969696"/>
-            <paletteEntry alpha="255" value="210" label="210" color="#969696"/>
-            <paletteEntry alpha="255" value="211" label="211" color="#969696"/>
-            <paletteEntry alpha="255" value="212" label="212" color="#969696"/>
-            <paletteEntry alpha="255" value="213" label="213" color="#969696"/>
-            <paletteEntry alpha="255" value="214" label="214" color="#969696"/>
-            <paletteEntry alpha="255" value="215" label="215" color="#969696"/>
-            <paletteEntry alpha="255" value="216" label="216" color="#969696"/>
-            <paletteEntry alpha="255" value="217" label="217" color="#969696"/>
-            <paletteEntry alpha="255" value="218" label="218" color="#969696"/>
-            <paletteEntry alpha="255" value="219" label="219" color="#969696"/>
-            <paletteEntry alpha="255" value="220" label="220" color="#969696"/>
-            <paletteEntry alpha="255" value="221" label="221" color="#969696"/>
-            <paletteEntry alpha="255" value="222" label="222" color="#969696"/>
-            <paletteEntry alpha="255" value="223" label="223" color="#969696"/>
-            <paletteEntry alpha="255" value="224" label="224" color="#969696"/>
-            <paletteEntry alpha="255" value="225" label="225" color="#969696"/>
-            <paletteEntry alpha="255" value="226" label="226" color="#969696"/>
-            <paletteEntry alpha="255" value="227" label="227" color="#969696"/>
-            <paletteEntry alpha="255" value="228" label="228" color="#969696"/>
-            <paletteEntry alpha="255" value="229" label="229" color="#969696"/>
-            <paletteEntry alpha="255" value="230" label="230" color="#969696"/>
-            <paletteEntry alpha="255" value="231" label="231" color="#969696"/>
-            <paletteEntry alpha="255" value="232" label="232" color="#969696"/>
-            <paletteEntry alpha="255" value="233" label="233" color="#969696"/>
-            <paletteEntry alpha="255" value="234" label="234" color="#969696"/>
-            <paletteEntry alpha="255" value="235" label="235" color="#969696"/>
-            <paletteEntry alpha="255" value="236" label="236" color="#969696"/>
-            <paletteEntry alpha="255" value="237" label="237" color="#969696"/>
-            <paletteEntry alpha="255" value="238" label="238" color="#969696"/>
-            <paletteEntry alpha="255" value="239" label="239" color="#969696"/>
-            <paletteEntry alpha="255" value="240" label="240" color="#969696"/>
-            <paletteEntry alpha="255" value="241" label="241" color="#969696"/>
-            <paletteEntry alpha="255" value="242" label="242" color="#969696"/>
-            <paletteEntry alpha="255" value="243" label="243" color="#969696"/>
-            <paletteEntry alpha="255" value="244" label="244" color="#969696"/>
-            <paletteEntry alpha="255" value="245" label="245" color="#969696"/>
-            <paletteEntry alpha="255" value="246" label="246" color="#969696"/>
-            <paletteEntry alpha="255" value="247" label="247" color="#969696"/>
-            <paletteEntry alpha="255" value="248" label="248" color="#969696"/>
-            <paletteEntry alpha="255" value="249" label="249" color="#969696"/>
-            <paletteEntry alpha="255" value="250" label="250" color="#969696"/>
-            <paletteEntry alpha="255" value="251" label="251" color="#969696"/>
-            <paletteEntry alpha="255" value="252" label="252" color="#969696"/>
-            <paletteEntry alpha="255" value="253" label="253" color="#969696"/>
-            <paletteEntry alpha="255" value="254" label="254" color="#969696"/>
-            <paletteEntry alpha="255" value="255" label="255" color="#ffffff"/>
-          </colorPalette>
+          <redContrastEnhancement>
+            <minValue>90</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>90</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>90</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="5000" hasScaleBasedVisibilityFlag="1" minScale="9000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="9000" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="5000">
       <extent>
-        <xmin>2585000</xmin>
-        <ymin>1212000</ymin>
-        <xmax>2655000</xmax>
-        <ymax>1266000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk10_grau_relief_483ec29d_51d2_4dd1_9e59_03dd92ff5981</id>
-      <datasource>/geodata/ch.swisstopo.lk10.grau_relief/lk10_grau_relief.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk10_masked_grau_relief_c621e4bd_2c35_490c_a66e_185d91d96663</id>
+      <datasource>/geodata/ch.swisstopo.lk10.grau_relief/ch.swisstopo.lk10-masked.grau_relief.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk10.grau_relief</layername>
+      <layername>ch.swisstopo.lk10-masked.grau_relief</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1502,7 +1257,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1511,11 +1266,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1532,28 +1287,130 @@ def my_form_open(dialog, layer, feature):
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="229,182,54,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="229,182,54,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer gradient="BlackToWhite" nodataColor="" grayBand="1" opacity="1" type="singlebandgray" alphaBand="2">
+        <rasterrenderer type="singlebandgray" alphaBand="2" opacity="1" grayBand="1" nodataColor="" gradient="BlackToWhite">
           <rasterTransparency/>
           <minMaxOrigin>
             <limits>MinMax</limits>
@@ -1568,37 +1425,56 @@ def my_form_open(dialog, layer, feature):
             <maxValue>255</maxValue>
             <algorithm>StretchToMinimumMaximum</algorithm>
           </contrastEnhancement>
+          <rampLegendSettings useContinuousLegend="1" orientation="2" prefix="" minimumLabel="" direction="0" maximumLabel="" suffix="">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option type="invalid" name="decimal_separator"/>
+                <Option type="int" value="6" name="decimals"/>
+                <Option type="int" value="0" name="rounding_type"/>
+                <Option type="bool" value="false" name="show_plus"/>
+                <Option type="bool" value="true" name="show_thousand_separator"/>
+                <Option type="bool" value="false" name="show_trailing_zeros"/>
+                <Option type="invalid" name="thousand_separator"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="70000" hasScaleBasedVisibilityFlag="1" minScale="150000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="150000" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="70000">
       <extent>
-        <xmin>2443000</xmin>
-        <ymin>1024000</ymin>
-        <xmax>2895000</xmax>
-        <ymax>1340000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk200_grau_e12b1615_28d6_4f6e_b42e_016d8c29cda5</id>
-      <datasource>/geodata/ch.swisstopo.lk200.grau/lk200_grau.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk200_masked_grau_a274694a_01b5_4f25_90de_42e543e1b247</id>
+      <datasource>/geodata/ch.swisstopo.lk200.grau/ch.swisstopo.lk200-masked.grau.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk200.grau</layername>
+      <layername>ch.swisstopo.lk200-masked.grau</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1622,7 +1498,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -1631,11 +1507,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1648,331 +1524,197 @@ def my_form_open(dialog, layer, feature):
       <noData>
         <noDataList useSrcNoData="0" bandNo="1"/>
         <noDataList useSrcNoData="0" bandNo="2"/>
+        <noDataList useSrcNoData="0" bandNo="3"/>
+        <noDataList useSrcNoData="0" bandNo="4"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="231,113,72,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="231,113,72,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="4" zoomedOutResamplingMethod="bilinear" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="2">
+        <rasterrenderer blueBand="3" type="multibandcolor" alphaBand="4" opacity="1" nodataColor="" greenBand="2" redBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="0" label="0" color="#000000"/>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-            <paletteEntry alpha="255" value="2" label="2" color="#e7e7e7"/>
-            <paletteEntry alpha="255" value="3" label="3" color="#d3d3d3"/>
-            <paletteEntry alpha="255" value="4" label="4" color="#cacacb"/>
-            <paletteEntry alpha="255" value="5" label="5" color="#cacaca"/>
-            <paletteEntry alpha="255" value="6" label="6" color="#a7a7a7"/>
-            <paletteEntry alpha="255" value="7" label="7" color="#9e9e9e"/>
-            <paletteEntry alpha="255" value="8" label="8" color="#d1d1d1"/>
-            <paletteEntry alpha="255" value="9" label="9" color="#c7c7c7"/>
-            <paletteEntry alpha="255" value="10" label="10" color="#b3b3b4"/>
-            <paletteEntry alpha="255" value="11" label="11" color="#feffff"/>
-            <paletteEntry alpha="255" value="12" label="12" color="#fffefe"/>
-            <paletteEntry alpha="255" value="13" label="13" color="#fefffe"/>
-            <paletteEntry alpha="255" value="14" label="14" color="#8f8f8f"/>
-            <paletteEntry alpha="255" value="15" label="15" color="#8a8a8a"/>
-            <paletteEntry alpha="255" value="16" label="16" color="#fcfcfc"/>
-            <paletteEntry alpha="255" value="17" label="17" color="#6a6a6a"/>
-            <paletteEntry alpha="255" value="18" label="18" color="#646464"/>
-            <paletteEntry alpha="255" value="19" label="19" color="#5e5e5e"/>
-            <paletteEntry alpha="255" value="20" label="20" color="#000002"/>
-            <paletteEntry alpha="255" value="21" label="21" color="#010000"/>
-            <paletteEntry alpha="255" value="22" label="22" color="#000200"/>
-            <paletteEntry alpha="255" value="23" label="23" color="#020000"/>
-            <paletteEntry alpha="255" value="24" label="24" color="#000001"/>
-            <paletteEntry alpha="255" value="25" label="25" color="#010100"/>
-            <paletteEntry alpha="255" value="26" label="26" color="#010001"/>
-            <paletteEntry alpha="255" value="27" label="27" color="#000101"/>
-            <paletteEntry alpha="255" value="28" label="28" color="#969696"/>
-            <paletteEntry alpha="255" value="29" label="29" color="#969696"/>
-            <paletteEntry alpha="255" value="30" label="30" color="#969696"/>
-            <paletteEntry alpha="255" value="31" label="31" color="#969696"/>
-            <paletteEntry alpha="255" value="32" label="32" color="#969696"/>
-            <paletteEntry alpha="255" value="33" label="33" color="#969696"/>
-            <paletteEntry alpha="255" value="34" label="34" color="#969696"/>
-            <paletteEntry alpha="255" value="35" label="35" color="#969696"/>
-            <paletteEntry alpha="255" value="36" label="36" color="#969696"/>
-            <paletteEntry alpha="255" value="37" label="37" color="#969696"/>
-            <paletteEntry alpha="255" value="38" label="38" color="#969696"/>
-            <paletteEntry alpha="255" value="39" label="39" color="#969696"/>
-            <paletteEntry alpha="255" value="40" label="40" color="#969696"/>
-            <paletteEntry alpha="255" value="41" label="41" color="#969696"/>
-            <paletteEntry alpha="255" value="42" label="42" color="#969696"/>
-            <paletteEntry alpha="255" value="43" label="43" color="#969696"/>
-            <paletteEntry alpha="255" value="44" label="44" color="#969696"/>
-            <paletteEntry alpha="255" value="45" label="45" color="#969696"/>
-            <paletteEntry alpha="255" value="46" label="46" color="#969696"/>
-            <paletteEntry alpha="255" value="47" label="47" color="#969696"/>
-            <paletteEntry alpha="255" value="48" label="48" color="#969696"/>
-            <paletteEntry alpha="255" value="49" label="49" color="#969696"/>
-            <paletteEntry alpha="255" value="50" label="50" color="#969696"/>
-            <paletteEntry alpha="255" value="51" label="51" color="#969696"/>
-            <paletteEntry alpha="255" value="52" label="52" color="#969696"/>
-            <paletteEntry alpha="255" value="53" label="53" color="#969696"/>
-            <paletteEntry alpha="255" value="54" label="54" color="#969696"/>
-            <paletteEntry alpha="255" value="55" label="55" color="#969696"/>
-            <paletteEntry alpha="255" value="56" label="56" color="#969696"/>
-            <paletteEntry alpha="255" value="57" label="57" color="#969696"/>
-            <paletteEntry alpha="255" value="58" label="58" color="#969696"/>
-            <paletteEntry alpha="255" value="59" label="59" color="#969696"/>
-            <paletteEntry alpha="255" value="60" label="60" color="#969696"/>
-            <paletteEntry alpha="255" value="61" label="61" color="#969696"/>
-            <paletteEntry alpha="255" value="62" label="62" color="#969696"/>
-            <paletteEntry alpha="255" value="63" label="63" color="#969696"/>
-            <paletteEntry alpha="255" value="64" label="64" color="#969696"/>
-            <paletteEntry alpha="255" value="65" label="65" color="#969696"/>
-            <paletteEntry alpha="255" value="66" label="66" color="#969696"/>
-            <paletteEntry alpha="255" value="67" label="67" color="#969696"/>
-            <paletteEntry alpha="255" value="68" label="68" color="#969696"/>
-            <paletteEntry alpha="255" value="69" label="69" color="#969696"/>
-            <paletteEntry alpha="255" value="70" label="70" color="#969696"/>
-            <paletteEntry alpha="255" value="71" label="71" color="#969696"/>
-            <paletteEntry alpha="255" value="72" label="72" color="#969696"/>
-            <paletteEntry alpha="255" value="73" label="73" color="#969696"/>
-            <paletteEntry alpha="255" value="74" label="74" color="#969696"/>
-            <paletteEntry alpha="255" value="75" label="75" color="#969696"/>
-            <paletteEntry alpha="255" value="76" label="76" color="#969696"/>
-            <paletteEntry alpha="255" value="77" label="77" color="#969696"/>
-            <paletteEntry alpha="255" value="78" label="78" color="#969696"/>
-            <paletteEntry alpha="255" value="79" label="79" color="#969696"/>
-            <paletteEntry alpha="255" value="80" label="80" color="#969696"/>
-            <paletteEntry alpha="255" value="81" label="81" color="#969696"/>
-            <paletteEntry alpha="255" value="82" label="82" color="#969696"/>
-            <paletteEntry alpha="255" value="83" label="83" color="#969696"/>
-            <paletteEntry alpha="255" value="84" label="84" color="#969696"/>
-            <paletteEntry alpha="255" value="85" label="85" color="#969696"/>
-            <paletteEntry alpha="255" value="86" label="86" color="#969696"/>
-            <paletteEntry alpha="255" value="87" label="87" color="#969696"/>
-            <paletteEntry alpha="255" value="88" label="88" color="#969696"/>
-            <paletteEntry alpha="255" value="89" label="89" color="#969696"/>
-            <paletteEntry alpha="255" value="90" label="90" color="#969696"/>
-            <paletteEntry alpha="255" value="91" label="91" color="#969696"/>
-            <paletteEntry alpha="255" value="92" label="92" color="#969696"/>
-            <paletteEntry alpha="255" value="93" label="93" color="#969696"/>
-            <paletteEntry alpha="255" value="94" label="94" color="#969696"/>
-            <paletteEntry alpha="255" value="95" label="95" color="#969696"/>
-            <paletteEntry alpha="255" value="96" label="96" color="#969696"/>
-            <paletteEntry alpha="255" value="97" label="97" color="#969696"/>
-            <paletteEntry alpha="255" value="98" label="98" color="#969696"/>
-            <paletteEntry alpha="255" value="99" label="99" color="#969696"/>
-            <paletteEntry alpha="255" value="100" label="100" color="#969696"/>
-            <paletteEntry alpha="255" value="101" label="101" color="#969696"/>
-            <paletteEntry alpha="255" value="102" label="102" color="#969696"/>
-            <paletteEntry alpha="255" value="103" label="103" color="#969696"/>
-            <paletteEntry alpha="255" value="104" label="104" color="#969696"/>
-            <paletteEntry alpha="255" value="105" label="105" color="#969696"/>
-            <paletteEntry alpha="255" value="106" label="106" color="#969696"/>
-            <paletteEntry alpha="255" value="107" label="107" color="#969696"/>
-            <paletteEntry alpha="255" value="108" label="108" color="#969696"/>
-            <paletteEntry alpha="255" value="109" label="109" color="#969696"/>
-            <paletteEntry alpha="255" value="110" label="110" color="#969696"/>
-            <paletteEntry alpha="255" value="111" label="111" color="#969696"/>
-            <paletteEntry alpha="255" value="112" label="112" color="#969696"/>
-            <paletteEntry alpha="255" value="113" label="113" color="#969696"/>
-            <paletteEntry alpha="255" value="114" label="114" color="#969696"/>
-            <paletteEntry alpha="255" value="115" label="115" color="#969696"/>
-            <paletteEntry alpha="255" value="116" label="116" color="#969696"/>
-            <paletteEntry alpha="255" value="117" label="117" color="#969696"/>
-            <paletteEntry alpha="255" value="118" label="118" color="#969696"/>
-            <paletteEntry alpha="255" value="119" label="119" color="#969696"/>
-            <paletteEntry alpha="255" value="120" label="120" color="#969696"/>
-            <paletteEntry alpha="255" value="121" label="121" color="#969696"/>
-            <paletteEntry alpha="255" value="122" label="122" color="#969696"/>
-            <paletteEntry alpha="255" value="123" label="123" color="#969696"/>
-            <paletteEntry alpha="255" value="124" label="124" color="#969696"/>
-            <paletteEntry alpha="255" value="125" label="125" color="#969696"/>
-            <paletteEntry alpha="255" value="126" label="126" color="#969696"/>
-            <paletteEntry alpha="255" value="127" label="127" color="#969696"/>
-            <paletteEntry alpha="255" value="128" label="128" color="#969696"/>
-            <paletteEntry alpha="255" value="129" label="129" color="#969696"/>
-            <paletteEntry alpha="255" value="130" label="130" color="#969696"/>
-            <paletteEntry alpha="255" value="131" label="131" color="#969696"/>
-            <paletteEntry alpha="255" value="132" label="132" color="#969696"/>
-            <paletteEntry alpha="255" value="133" label="133" color="#969696"/>
-            <paletteEntry alpha="255" value="134" label="134" color="#969696"/>
-            <paletteEntry alpha="255" value="135" label="135" color="#969696"/>
-            <paletteEntry alpha="255" value="136" label="136" color="#969696"/>
-            <paletteEntry alpha="255" value="137" label="137" color="#969696"/>
-            <paletteEntry alpha="255" value="138" label="138" color="#969696"/>
-            <paletteEntry alpha="255" value="139" label="139" color="#969696"/>
-            <paletteEntry alpha="255" value="140" label="140" color="#969696"/>
-            <paletteEntry alpha="255" value="141" label="141" color="#969696"/>
-            <paletteEntry alpha="255" value="142" label="142" color="#969696"/>
-            <paletteEntry alpha="255" value="143" label="143" color="#969696"/>
-            <paletteEntry alpha="255" value="144" label="144" color="#969696"/>
-            <paletteEntry alpha="255" value="145" label="145" color="#969696"/>
-            <paletteEntry alpha="255" value="146" label="146" color="#969696"/>
-            <paletteEntry alpha="255" value="147" label="147" color="#969696"/>
-            <paletteEntry alpha="255" value="148" label="148" color="#969696"/>
-            <paletteEntry alpha="255" value="149" label="149" color="#969696"/>
-            <paletteEntry alpha="255" value="150" label="150" color="#969696"/>
-            <paletteEntry alpha="255" value="151" label="151" color="#969696"/>
-            <paletteEntry alpha="255" value="152" label="152" color="#969696"/>
-            <paletteEntry alpha="255" value="153" label="153" color="#969696"/>
-            <paletteEntry alpha="255" value="154" label="154" color="#969696"/>
-            <paletteEntry alpha="255" value="155" label="155" color="#969696"/>
-            <paletteEntry alpha="255" value="156" label="156" color="#969696"/>
-            <paletteEntry alpha="255" value="157" label="157" color="#969696"/>
-            <paletteEntry alpha="255" value="158" label="158" color="#969696"/>
-            <paletteEntry alpha="255" value="159" label="159" color="#969696"/>
-            <paletteEntry alpha="255" value="160" label="160" color="#969696"/>
-            <paletteEntry alpha="255" value="161" label="161" color="#969696"/>
-            <paletteEntry alpha="255" value="162" label="162" color="#969696"/>
-            <paletteEntry alpha="255" value="163" label="163" color="#969696"/>
-            <paletteEntry alpha="255" value="164" label="164" color="#969696"/>
-            <paletteEntry alpha="255" value="165" label="165" color="#969696"/>
-            <paletteEntry alpha="255" value="166" label="166" color="#969696"/>
-            <paletteEntry alpha="255" value="167" label="167" color="#969696"/>
-            <paletteEntry alpha="255" value="168" label="168" color="#969696"/>
-            <paletteEntry alpha="255" value="169" label="169" color="#969696"/>
-            <paletteEntry alpha="255" value="170" label="170" color="#969696"/>
-            <paletteEntry alpha="255" value="171" label="171" color="#969696"/>
-            <paletteEntry alpha="255" value="172" label="172" color="#969696"/>
-            <paletteEntry alpha="255" value="173" label="173" color="#969696"/>
-            <paletteEntry alpha="255" value="174" label="174" color="#969696"/>
-            <paletteEntry alpha="255" value="175" label="175" color="#969696"/>
-            <paletteEntry alpha="255" value="176" label="176" color="#969696"/>
-            <paletteEntry alpha="255" value="177" label="177" color="#969696"/>
-            <paletteEntry alpha="255" value="178" label="178" color="#969696"/>
-            <paletteEntry alpha="255" value="179" label="179" color="#969696"/>
-            <paletteEntry alpha="255" value="180" label="180" color="#969696"/>
-            <paletteEntry alpha="255" value="181" label="181" color="#969696"/>
-            <paletteEntry alpha="255" value="182" label="182" color="#969696"/>
-            <paletteEntry alpha="255" value="183" label="183" color="#969696"/>
-            <paletteEntry alpha="255" value="184" label="184" color="#969696"/>
-            <paletteEntry alpha="255" value="185" label="185" color="#969696"/>
-            <paletteEntry alpha="255" value="186" label="186" color="#969696"/>
-            <paletteEntry alpha="255" value="187" label="187" color="#969696"/>
-            <paletteEntry alpha="255" value="188" label="188" color="#969696"/>
-            <paletteEntry alpha="255" value="189" label="189" color="#969696"/>
-            <paletteEntry alpha="255" value="190" label="190" color="#969696"/>
-            <paletteEntry alpha="255" value="191" label="191" color="#969696"/>
-            <paletteEntry alpha="255" value="192" label="192" color="#969696"/>
-            <paletteEntry alpha="255" value="193" label="193" color="#969696"/>
-            <paletteEntry alpha="255" value="194" label="194" color="#969696"/>
-            <paletteEntry alpha="255" value="195" label="195" color="#969696"/>
-            <paletteEntry alpha="255" value="196" label="196" color="#969696"/>
-            <paletteEntry alpha="255" value="197" label="197" color="#969696"/>
-            <paletteEntry alpha="255" value="198" label="198" color="#969696"/>
-            <paletteEntry alpha="255" value="199" label="199" color="#969696"/>
-            <paletteEntry alpha="255" value="200" label="200" color="#969696"/>
-            <paletteEntry alpha="255" value="201" label="201" color="#969696"/>
-            <paletteEntry alpha="255" value="202" label="202" color="#969696"/>
-            <paletteEntry alpha="255" value="203" label="203" color="#969696"/>
-            <paletteEntry alpha="255" value="204" label="204" color="#969696"/>
-            <paletteEntry alpha="255" value="205" label="205" color="#969696"/>
-            <paletteEntry alpha="255" value="206" label="206" color="#969696"/>
-            <paletteEntry alpha="255" value="207" label="207" color="#969696"/>
-            <paletteEntry alpha="255" value="208" label="208" color="#969696"/>
-            <paletteEntry alpha="255" value="209" label="209" color="#969696"/>
-            <paletteEntry alpha="255" value="210" label="210" color="#969696"/>
-            <paletteEntry alpha="255" value="211" label="211" color="#969696"/>
-            <paletteEntry alpha="255" value="212" label="212" color="#969696"/>
-            <paletteEntry alpha="255" value="213" label="213" color="#969696"/>
-            <paletteEntry alpha="255" value="214" label="214" color="#969696"/>
-            <paletteEntry alpha="255" value="215" label="215" color="#969696"/>
-            <paletteEntry alpha="255" value="216" label="216" color="#969696"/>
-            <paletteEntry alpha="255" value="217" label="217" color="#969696"/>
-            <paletteEntry alpha="255" value="218" label="218" color="#969696"/>
-            <paletteEntry alpha="255" value="219" label="219" color="#969696"/>
-            <paletteEntry alpha="255" value="220" label="220" color="#969696"/>
-            <paletteEntry alpha="255" value="221" label="221" color="#969696"/>
-            <paletteEntry alpha="255" value="222" label="222" color="#969696"/>
-            <paletteEntry alpha="255" value="223" label="223" color="#969696"/>
-            <paletteEntry alpha="255" value="224" label="224" color="#969696"/>
-            <paletteEntry alpha="255" value="225" label="225" color="#969696"/>
-            <paletteEntry alpha="255" value="226" label="226" color="#969696"/>
-            <paletteEntry alpha="255" value="227" label="227" color="#969696"/>
-            <paletteEntry alpha="255" value="228" label="228" color="#969696"/>
-            <paletteEntry alpha="255" value="229" label="229" color="#969696"/>
-            <paletteEntry alpha="255" value="230" label="230" color="#969696"/>
-            <paletteEntry alpha="255" value="231" label="231" color="#969696"/>
-            <paletteEntry alpha="255" value="232" label="232" color="#969696"/>
-            <paletteEntry alpha="255" value="233" label="233" color="#969696"/>
-            <paletteEntry alpha="255" value="234" label="234" color="#969696"/>
-            <paletteEntry alpha="255" value="235" label="235" color="#969696"/>
-            <paletteEntry alpha="255" value="236" label="236" color="#969696"/>
-            <paletteEntry alpha="255" value="237" label="237" color="#969696"/>
-            <paletteEntry alpha="255" value="238" label="238" color="#969696"/>
-            <paletteEntry alpha="255" value="239" label="239" color="#969696"/>
-            <paletteEntry alpha="255" value="240" label="240" color="#969696"/>
-            <paletteEntry alpha="255" value="241" label="241" color="#969696"/>
-            <paletteEntry alpha="255" value="242" label="242" color="#969696"/>
-            <paletteEntry alpha="255" value="243" label="243" color="#969696"/>
-            <paletteEntry alpha="255" value="244" label="244" color="#969696"/>
-            <paletteEntry alpha="255" value="245" label="245" color="#969696"/>
-            <paletteEntry alpha="255" value="246" label="246" color="#969696"/>
-            <paletteEntry alpha="255" value="247" label="247" color="#969696"/>
-            <paletteEntry alpha="255" value="248" label="248" color="#969696"/>
-            <paletteEntry alpha="255" value="249" label="249" color="#969696"/>
-            <paletteEntry alpha="255" value="250" label="250" color="#969696"/>
-            <paletteEntry alpha="255" value="251" label="251" color="#969696"/>
-            <paletteEntry alpha="255" value="252" label="252" color="#969696"/>
-            <paletteEntry alpha="255" value="253" label="253" color="#969696"/>
-            <paletteEntry alpha="255" value="254" label="254" color="#969696"/>
-            <paletteEntry alpha="255" value="255" label="255" color="#ffffff"/>
-          </colorPalette>
-          <colorramp name="[source]" type="randomcolors"/>
+          <redContrastEnhancement>
+            <minValue>71</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>70</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>71</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="9000" hasScaleBasedVisibilityFlag="1" minScale="18000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="18000" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="9000">
       <extent>
-        <xmin>2585000</xmin>
-        <ymin>1206000</ymin>
-        <xmax>2655000</xmax>
-        <ymax>1266000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk25_grau_eea4cf2f_880c_47c7_a6d0_af9334bc87d6</id>
-      <datasource>/geodata/ch.swisstopo.lk25.grau/lk25_grau.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk25_masked_grau_c84f613e_12e8_4d93_8e56_cd85bdc3d065</id>
+      <datasource>/geodata/ch.swisstopo.lk25.grau/ch.swisstopo.lk25-masked.grau.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk25.grau</layername>
+      <layername>ch.swisstopo.lk25-masked.grau</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -1996,7 +1738,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -2005,11 +1747,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -2022,330 +1764,197 @@ def my_form_open(dialog, layer, feature):
       <noData>
         <noDataList useSrcNoData="0" bandNo="1"/>
         <noDataList useSrcNoData="0" bandNo="2"/>
+        <noDataList useSrcNoData="0" bandNo="3"/>
+        <noDataList useSrcNoData="0" bandNo="4"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="225,89,137,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="225,89,137,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="2">
+        <rasterrenderer blueBand="3" type="multibandcolor" alphaBand="4" opacity="1" nodataColor="" greenBand="2" redBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="0" label="0" color="#000000"/>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-            <paletteEntry alpha="255" value="2" label="2" color="#f4f4f4"/>
-            <paletteEntry alpha="255" value="3" label="3" color="#e7e7e7"/>
-            <paletteEntry alpha="255" value="4" label="4" color="#d3d3d3"/>
-            <paletteEntry alpha="255" value="5" label="5" color="#cacacb"/>
-            <paletteEntry alpha="255" value="6" label="6" color="#969696"/>
-            <paletteEntry alpha="255" value="7" label="7" color="#c5c5c5"/>
-            <paletteEntry alpha="255" value="8" label="8" color="#a7a7a7"/>
-            <paletteEntry alpha="255" value="9" label="9" color="#a3a3a3"/>
-            <paletteEntry alpha="255" value="10" label="10" color="#9e9e9e"/>
-            <paletteEntry alpha="255" value="11" label="11" color="#d1d1d1"/>
-            <paletteEntry alpha="255" value="12" label="12" color="#b3b3b3"/>
-            <paletteEntry alpha="255" value="13" label="13" color="#b3b3b4"/>
-            <paletteEntry alpha="255" value="14" label="14" color="#8f8f8f"/>
-            <paletteEntry alpha="255" value="15" label="15" color="#8d8d8d"/>
-            <paletteEntry alpha="255" value="16" label="16" color="#8a8a8a"/>
-            <paletteEntry alpha="255" value="17" label="17" color="#fcfcfc"/>
-            <paletteEntry alpha="255" value="18" label="18" color="#f8f8f8"/>
-            <paletteEntry alpha="255" value="19" label="19" color="#6a6a6a"/>
-            <paletteEntry alpha="255" value="20" label="20" color="#676767"/>
-            <paletteEntry alpha="255" value="21" label="21" color="#646464"/>
-            <paletteEntry alpha="255" value="22" label="22" color="#626262"/>
-            <paletteEntry alpha="255" value="23" label="23" color="#5e5e5e"/>
-            <paletteEntry alpha="255" value="24" label="24" color="#3e3e3e"/>
-            <paletteEntry alpha="255" value="25" label="25" color="#010000"/>
-            <paletteEntry alpha="255" value="26" label="26" color="#3e3e3f"/>
-            <paletteEntry alpha="255" value="27" label="27" color="#3e3f3e"/>
-            <paletteEntry alpha="255" value="28" label="28" color="#000001"/>
-            <paletteEntry alpha="255" value="29" label="29" color="#010100"/>
-            <paletteEntry alpha="255" value="30" label="30" color="#010001"/>
-            <paletteEntry alpha="255" value="31" label="31" color="#000101"/>
-            <paletteEntry alpha="255" value="32" label="32" color="#fffffe"/>
-            <paletteEntry alpha="255" value="33" label="33" color="#fffeff"/>
-            <paletteEntry alpha="255" value="34" label="34" color="#feffff"/>
-            <paletteEntry alpha="255" value="35" label="35" color="#fffefe"/>
-            <paletteEntry alpha="255" value="36" label="36" color="#fefffe"/>
-            <paletteEntry alpha="255" value="37" label="37" color="#fefeff"/>
-            <paletteEntry alpha="255" value="38" label="38" color="#cacaca"/>
-            <paletteEntry alpha="255" value="39" label="39" color="#969696"/>
-            <paletteEntry alpha="255" value="40" label="40" color="#969696"/>
-            <paletteEntry alpha="255" value="41" label="41" color="#969696"/>
-            <paletteEntry alpha="255" value="42" label="42" color="#969696"/>
-            <paletteEntry alpha="255" value="43" label="43" color="#969696"/>
-            <paletteEntry alpha="255" value="44" label="44" color="#969696"/>
-            <paletteEntry alpha="255" value="45" label="45" color="#969696"/>
-            <paletteEntry alpha="255" value="46" label="46" color="#969696"/>
-            <paletteEntry alpha="255" value="47" label="47" color="#969696"/>
-            <paletteEntry alpha="255" value="48" label="48" color="#969696"/>
-            <paletteEntry alpha="255" value="49" label="49" color="#969696"/>
-            <paletteEntry alpha="255" value="50" label="50" color="#969696"/>
-            <paletteEntry alpha="255" value="51" label="51" color="#969696"/>
-            <paletteEntry alpha="255" value="52" label="52" color="#969696"/>
-            <paletteEntry alpha="255" value="53" label="53" color="#969696"/>
-            <paletteEntry alpha="255" value="54" label="54" color="#969696"/>
-            <paletteEntry alpha="255" value="55" label="55" color="#969696"/>
-            <paletteEntry alpha="255" value="56" label="56" color="#969696"/>
-            <paletteEntry alpha="255" value="57" label="57" color="#969696"/>
-            <paletteEntry alpha="255" value="58" label="58" color="#969696"/>
-            <paletteEntry alpha="255" value="59" label="59" color="#969696"/>
-            <paletteEntry alpha="255" value="60" label="60" color="#969696"/>
-            <paletteEntry alpha="255" value="61" label="61" color="#969696"/>
-            <paletteEntry alpha="255" value="62" label="62" color="#969696"/>
-            <paletteEntry alpha="255" value="63" label="63" color="#969696"/>
-            <paletteEntry alpha="255" value="64" label="64" color="#969696"/>
-            <paletteEntry alpha="255" value="65" label="65" color="#969696"/>
-            <paletteEntry alpha="255" value="66" label="66" color="#969696"/>
-            <paletteEntry alpha="255" value="67" label="67" color="#969696"/>
-            <paletteEntry alpha="255" value="68" label="68" color="#969696"/>
-            <paletteEntry alpha="255" value="69" label="69" color="#969696"/>
-            <paletteEntry alpha="255" value="70" label="70" color="#969696"/>
-            <paletteEntry alpha="255" value="71" label="71" color="#969696"/>
-            <paletteEntry alpha="255" value="72" label="72" color="#969696"/>
-            <paletteEntry alpha="255" value="73" label="73" color="#969696"/>
-            <paletteEntry alpha="255" value="74" label="74" color="#969696"/>
-            <paletteEntry alpha="255" value="75" label="75" color="#969696"/>
-            <paletteEntry alpha="255" value="76" label="76" color="#969696"/>
-            <paletteEntry alpha="255" value="77" label="77" color="#969696"/>
-            <paletteEntry alpha="255" value="78" label="78" color="#969696"/>
-            <paletteEntry alpha="255" value="79" label="79" color="#969696"/>
-            <paletteEntry alpha="255" value="80" label="80" color="#969696"/>
-            <paletteEntry alpha="255" value="81" label="81" color="#969696"/>
-            <paletteEntry alpha="255" value="82" label="82" color="#969696"/>
-            <paletteEntry alpha="255" value="83" label="83" color="#969696"/>
-            <paletteEntry alpha="255" value="84" label="84" color="#969696"/>
-            <paletteEntry alpha="255" value="85" label="85" color="#969696"/>
-            <paletteEntry alpha="255" value="86" label="86" color="#969696"/>
-            <paletteEntry alpha="255" value="87" label="87" color="#969696"/>
-            <paletteEntry alpha="255" value="88" label="88" color="#969696"/>
-            <paletteEntry alpha="255" value="89" label="89" color="#969696"/>
-            <paletteEntry alpha="255" value="90" label="90" color="#969696"/>
-            <paletteEntry alpha="255" value="91" label="91" color="#969696"/>
-            <paletteEntry alpha="255" value="92" label="92" color="#969696"/>
-            <paletteEntry alpha="255" value="93" label="93" color="#969696"/>
-            <paletteEntry alpha="255" value="94" label="94" color="#969696"/>
-            <paletteEntry alpha="255" value="95" label="95" color="#969696"/>
-            <paletteEntry alpha="255" value="96" label="96" color="#969696"/>
-            <paletteEntry alpha="255" value="97" label="97" color="#969696"/>
-            <paletteEntry alpha="255" value="98" label="98" color="#969696"/>
-            <paletteEntry alpha="255" value="99" label="99" color="#969696"/>
-            <paletteEntry alpha="255" value="100" label="100" color="#969696"/>
-            <paletteEntry alpha="255" value="101" label="101" color="#969696"/>
-            <paletteEntry alpha="255" value="102" label="102" color="#969696"/>
-            <paletteEntry alpha="255" value="103" label="103" color="#969696"/>
-            <paletteEntry alpha="255" value="104" label="104" color="#969696"/>
-            <paletteEntry alpha="255" value="105" label="105" color="#969696"/>
-            <paletteEntry alpha="255" value="106" label="106" color="#969696"/>
-            <paletteEntry alpha="255" value="107" label="107" color="#969696"/>
-            <paletteEntry alpha="255" value="108" label="108" color="#969696"/>
-            <paletteEntry alpha="255" value="109" label="109" color="#969696"/>
-            <paletteEntry alpha="255" value="110" label="110" color="#969696"/>
-            <paletteEntry alpha="255" value="111" label="111" color="#969696"/>
-            <paletteEntry alpha="255" value="112" label="112" color="#969696"/>
-            <paletteEntry alpha="255" value="113" label="113" color="#969696"/>
-            <paletteEntry alpha="255" value="114" label="114" color="#969696"/>
-            <paletteEntry alpha="255" value="115" label="115" color="#969696"/>
-            <paletteEntry alpha="255" value="116" label="116" color="#969696"/>
-            <paletteEntry alpha="255" value="117" label="117" color="#969696"/>
-            <paletteEntry alpha="255" value="118" label="118" color="#969696"/>
-            <paletteEntry alpha="255" value="119" label="119" color="#969696"/>
-            <paletteEntry alpha="255" value="120" label="120" color="#969696"/>
-            <paletteEntry alpha="255" value="121" label="121" color="#969696"/>
-            <paletteEntry alpha="255" value="122" label="122" color="#969696"/>
-            <paletteEntry alpha="255" value="123" label="123" color="#969696"/>
-            <paletteEntry alpha="255" value="124" label="124" color="#969696"/>
-            <paletteEntry alpha="255" value="125" label="125" color="#969696"/>
-            <paletteEntry alpha="255" value="126" label="126" color="#969696"/>
-            <paletteEntry alpha="255" value="127" label="127" color="#969696"/>
-            <paletteEntry alpha="255" value="128" label="128" color="#969696"/>
-            <paletteEntry alpha="255" value="129" label="129" color="#969696"/>
-            <paletteEntry alpha="255" value="130" label="130" color="#969696"/>
-            <paletteEntry alpha="255" value="131" label="131" color="#969696"/>
-            <paletteEntry alpha="255" value="132" label="132" color="#969696"/>
-            <paletteEntry alpha="255" value="133" label="133" color="#969696"/>
-            <paletteEntry alpha="255" value="134" label="134" color="#969696"/>
-            <paletteEntry alpha="255" value="135" label="135" color="#969696"/>
-            <paletteEntry alpha="255" value="136" label="136" color="#969696"/>
-            <paletteEntry alpha="255" value="137" label="137" color="#969696"/>
-            <paletteEntry alpha="255" value="138" label="138" color="#969696"/>
-            <paletteEntry alpha="255" value="139" label="139" color="#969696"/>
-            <paletteEntry alpha="255" value="140" label="140" color="#969696"/>
-            <paletteEntry alpha="255" value="141" label="141" color="#969696"/>
-            <paletteEntry alpha="255" value="142" label="142" color="#969696"/>
-            <paletteEntry alpha="255" value="143" label="143" color="#969696"/>
-            <paletteEntry alpha="255" value="144" label="144" color="#969696"/>
-            <paletteEntry alpha="255" value="145" label="145" color="#969696"/>
-            <paletteEntry alpha="255" value="146" label="146" color="#969696"/>
-            <paletteEntry alpha="255" value="147" label="147" color="#969696"/>
-            <paletteEntry alpha="255" value="148" label="148" color="#969696"/>
-            <paletteEntry alpha="255" value="149" label="149" color="#969696"/>
-            <paletteEntry alpha="255" value="150" label="150" color="#969696"/>
-            <paletteEntry alpha="255" value="151" label="151" color="#969696"/>
-            <paletteEntry alpha="255" value="152" label="152" color="#969696"/>
-            <paletteEntry alpha="255" value="153" label="153" color="#969696"/>
-            <paletteEntry alpha="255" value="154" label="154" color="#969696"/>
-            <paletteEntry alpha="255" value="155" label="155" color="#969696"/>
-            <paletteEntry alpha="255" value="156" label="156" color="#969696"/>
-            <paletteEntry alpha="255" value="157" label="157" color="#969696"/>
-            <paletteEntry alpha="255" value="158" label="158" color="#969696"/>
-            <paletteEntry alpha="255" value="159" label="159" color="#969696"/>
-            <paletteEntry alpha="255" value="160" label="160" color="#969696"/>
-            <paletteEntry alpha="255" value="161" label="161" color="#969696"/>
-            <paletteEntry alpha="255" value="162" label="162" color="#969696"/>
-            <paletteEntry alpha="255" value="163" label="163" color="#969696"/>
-            <paletteEntry alpha="255" value="164" label="164" color="#969696"/>
-            <paletteEntry alpha="255" value="165" label="165" color="#969696"/>
-            <paletteEntry alpha="255" value="166" label="166" color="#969696"/>
-            <paletteEntry alpha="255" value="167" label="167" color="#969696"/>
-            <paletteEntry alpha="255" value="168" label="168" color="#969696"/>
-            <paletteEntry alpha="255" value="169" label="169" color="#969696"/>
-            <paletteEntry alpha="255" value="170" label="170" color="#969696"/>
-            <paletteEntry alpha="255" value="171" label="171" color="#969696"/>
-            <paletteEntry alpha="255" value="172" label="172" color="#969696"/>
-            <paletteEntry alpha="255" value="173" label="173" color="#969696"/>
-            <paletteEntry alpha="255" value="174" label="174" color="#969696"/>
-            <paletteEntry alpha="255" value="175" label="175" color="#969696"/>
-            <paletteEntry alpha="255" value="176" label="176" color="#969696"/>
-            <paletteEntry alpha="255" value="177" label="177" color="#969696"/>
-            <paletteEntry alpha="255" value="178" label="178" color="#969696"/>
-            <paletteEntry alpha="255" value="179" label="179" color="#969696"/>
-            <paletteEntry alpha="255" value="180" label="180" color="#969696"/>
-            <paletteEntry alpha="255" value="181" label="181" color="#969696"/>
-            <paletteEntry alpha="255" value="182" label="182" color="#969696"/>
-            <paletteEntry alpha="255" value="183" label="183" color="#969696"/>
-            <paletteEntry alpha="255" value="184" label="184" color="#969696"/>
-            <paletteEntry alpha="255" value="185" label="185" color="#969696"/>
-            <paletteEntry alpha="255" value="186" label="186" color="#969696"/>
-            <paletteEntry alpha="255" value="187" label="187" color="#969696"/>
-            <paletteEntry alpha="255" value="188" label="188" color="#969696"/>
-            <paletteEntry alpha="255" value="189" label="189" color="#969696"/>
-            <paletteEntry alpha="255" value="190" label="190" color="#969696"/>
-            <paletteEntry alpha="255" value="191" label="191" color="#969696"/>
-            <paletteEntry alpha="255" value="192" label="192" color="#969696"/>
-            <paletteEntry alpha="255" value="193" label="193" color="#969696"/>
-            <paletteEntry alpha="255" value="194" label="194" color="#969696"/>
-            <paletteEntry alpha="255" value="195" label="195" color="#969696"/>
-            <paletteEntry alpha="255" value="196" label="196" color="#969696"/>
-            <paletteEntry alpha="255" value="197" label="197" color="#969696"/>
-            <paletteEntry alpha="255" value="198" label="198" color="#969696"/>
-            <paletteEntry alpha="255" value="199" label="199" color="#969696"/>
-            <paletteEntry alpha="255" value="200" label="200" color="#969696"/>
-            <paletteEntry alpha="255" value="201" label="201" color="#969696"/>
-            <paletteEntry alpha="255" value="202" label="202" color="#969696"/>
-            <paletteEntry alpha="255" value="203" label="203" color="#969696"/>
-            <paletteEntry alpha="255" value="204" label="204" color="#969696"/>
-            <paletteEntry alpha="255" value="205" label="205" color="#969696"/>
-            <paletteEntry alpha="255" value="206" label="206" color="#969696"/>
-            <paletteEntry alpha="255" value="207" label="207" color="#969696"/>
-            <paletteEntry alpha="255" value="208" label="208" color="#969696"/>
-            <paletteEntry alpha="255" value="209" label="209" color="#969696"/>
-            <paletteEntry alpha="255" value="210" label="210" color="#969696"/>
-            <paletteEntry alpha="255" value="211" label="211" color="#969696"/>
-            <paletteEntry alpha="255" value="212" label="212" color="#969696"/>
-            <paletteEntry alpha="255" value="213" label="213" color="#969696"/>
-            <paletteEntry alpha="255" value="214" label="214" color="#969696"/>
-            <paletteEntry alpha="255" value="215" label="215" color="#969696"/>
-            <paletteEntry alpha="255" value="216" label="216" color="#969696"/>
-            <paletteEntry alpha="255" value="217" label="217" color="#969696"/>
-            <paletteEntry alpha="255" value="218" label="218" color="#969696"/>
-            <paletteEntry alpha="255" value="219" label="219" color="#969696"/>
-            <paletteEntry alpha="255" value="220" label="220" color="#969696"/>
-            <paletteEntry alpha="255" value="221" label="221" color="#969696"/>
-            <paletteEntry alpha="255" value="222" label="222" color="#969696"/>
-            <paletteEntry alpha="255" value="223" label="223" color="#969696"/>
-            <paletteEntry alpha="255" value="224" label="224" color="#969696"/>
-            <paletteEntry alpha="255" value="225" label="225" color="#969696"/>
-            <paletteEntry alpha="255" value="226" label="226" color="#969696"/>
-            <paletteEntry alpha="255" value="227" label="227" color="#969696"/>
-            <paletteEntry alpha="255" value="228" label="228" color="#969696"/>
-            <paletteEntry alpha="255" value="229" label="229" color="#969696"/>
-            <paletteEntry alpha="255" value="230" label="230" color="#969696"/>
-            <paletteEntry alpha="255" value="231" label="231" color="#969696"/>
-            <paletteEntry alpha="255" value="232" label="232" color="#969696"/>
-            <paletteEntry alpha="255" value="233" label="233" color="#969696"/>
-            <paletteEntry alpha="255" value="234" label="234" color="#969696"/>
-            <paletteEntry alpha="255" value="235" label="235" color="#969696"/>
-            <paletteEntry alpha="255" value="236" label="236" color="#969696"/>
-            <paletteEntry alpha="255" value="237" label="237" color="#969696"/>
-            <paletteEntry alpha="255" value="238" label="238" color="#969696"/>
-            <paletteEntry alpha="255" value="239" label="239" color="#969696"/>
-            <paletteEntry alpha="255" value="240" label="240" color="#969696"/>
-            <paletteEntry alpha="255" value="241" label="241" color="#969696"/>
-            <paletteEntry alpha="255" value="242" label="242" color="#969696"/>
-            <paletteEntry alpha="255" value="243" label="243" color="#969696"/>
-            <paletteEntry alpha="255" value="244" label="244" color="#969696"/>
-            <paletteEntry alpha="255" value="245" label="245" color="#969696"/>
-            <paletteEntry alpha="255" value="246" label="246" color="#969696"/>
-            <paletteEntry alpha="255" value="247" label="247" color="#969696"/>
-            <paletteEntry alpha="255" value="248" label="248" color="#969696"/>
-            <paletteEntry alpha="255" value="249" label="249" color="#969696"/>
-            <paletteEntry alpha="255" value="250" label="250" color="#969696"/>
-            <paletteEntry alpha="255" value="251" label="251" color="#969696"/>
-            <paletteEntry alpha="255" value="252" label="252" color="#969696"/>
-            <paletteEntry alpha="255" value="253" label="253" color="#969696"/>
-            <paletteEntry alpha="255" value="254" label="254" color="#969696"/>
-            <paletteEntry alpha="255" value="255" label="255" color="#ffffff"/>
-          </colorPalette>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="18000" hasScaleBasedVisibilityFlag="1" minScale="35000" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="280000" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="150000">
       <extent>
-        <xmin>2585000</xmin>
-        <ymin>1206000</ymin>
-        <xmax>2655000</xmax>
-        <ymax>1278000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>lk50_grau_cec4728a_148c_4f79_82cb_060463e19d71</id>
-      <datasource>/geodata/ch.swisstopo.lk50.grau/lk50_grau.vrt</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk500_masked_grau_b0758e40_6ec8_486b_9882_1eaf90551462</id>
+      <datasource>/geodata/ch.swisstopo.lk500.grau/ch.swisstopo.lk500-masked.grau.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>ch.swisstopo.lk50.grau</layername>
+      <layername>ch.swisstopo.lk500-masked.grau</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -2369,7 +1978,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -2378,11 +1987,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -2395,330 +2004,197 @@ def my_form_open(dialog, layer, feature):
       <noData>
         <noDataList useSrcNoData="0" bandNo="1"/>
         <noDataList useSrcNoData="0" bandNo="2"/>
+        <noDataList useSrcNoData="0" bandNo="3"/>
+        <noDataList useSrcNoData="0" bandNo="4"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="183,72,75,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="183,72,75,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="2">
+        <rasterrenderer blueBand="3" type="multibandcolor" alphaBand="4" opacity="1" nodataColor="" greenBand="2" redBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="0" label="0" color="#000000"/>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-            <paletteEntry alpha="255" value="2" label="2" color="#f4f4f4"/>
-            <paletteEntry alpha="255" value="3" label="3" color="#e7e7e7"/>
-            <paletteEntry alpha="255" value="4" label="4" color="#d3d3d3"/>
-            <paletteEntry alpha="255" value="5" label="5" color="#cacacb"/>
-            <paletteEntry alpha="255" value="6" label="6" color="#969696"/>
-            <paletteEntry alpha="255" value="7" label="7" color="#c5c5c5"/>
-            <paletteEntry alpha="255" value="8" label="8" color="#a7a7a7"/>
-            <paletteEntry alpha="255" value="9" label="9" color="#a3a3a3"/>
-            <paletteEntry alpha="255" value="10" label="10" color="#9e9e9e"/>
-            <paletteEntry alpha="255" value="11" label="11" color="#d1d1d1"/>
-            <paletteEntry alpha="255" value="12" label="12" color="#b3b3b3"/>
-            <paletteEntry alpha="255" value="13" label="13" color="#b3b3b4"/>
-            <paletteEntry alpha="255" value="14" label="14" color="#8f8f8f"/>
-            <paletteEntry alpha="255" value="15" label="15" color="#8d8d8d"/>
-            <paletteEntry alpha="255" value="16" label="16" color="#8a8a8a"/>
-            <paletteEntry alpha="255" value="17" label="17" color="#fcfcfc"/>
-            <paletteEntry alpha="255" value="18" label="18" color="#f8f8f8"/>
-            <paletteEntry alpha="255" value="19" label="19" color="#6a6a6a"/>
-            <paletteEntry alpha="255" value="20" label="20" color="#676767"/>
-            <paletteEntry alpha="255" value="21" label="21" color="#646464"/>
-            <paletteEntry alpha="255" value="22" label="22" color="#626262"/>
-            <paletteEntry alpha="255" value="23" label="23" color="#5e5e5e"/>
-            <paletteEntry alpha="255" value="24" label="24" color="#1f1f1f"/>
-            <paletteEntry alpha="255" value="25" label="25" color="#010000"/>
-            <paletteEntry alpha="255" value="26" label="26" color="#1f1f20"/>
-            <paletteEntry alpha="255" value="27" label="27" color="#1f201f"/>
-            <paletteEntry alpha="255" value="28" label="28" color="#000001"/>
-            <paletteEntry alpha="255" value="29" label="29" color="#010100"/>
-            <paletteEntry alpha="255" value="30" label="30" color="#010001"/>
-            <paletteEntry alpha="255" value="31" label="31" color="#000101"/>
-            <paletteEntry alpha="255" value="32" label="32" color="#fffffe"/>
-            <paletteEntry alpha="255" value="33" label="33" color="#fffeff"/>
-            <paletteEntry alpha="255" value="34" label="34" color="#feffff"/>
-            <paletteEntry alpha="255" value="35" label="35" color="#fffefe"/>
-            <paletteEntry alpha="255" value="36" label="36" color="#fefffe"/>
-            <paletteEntry alpha="255" value="37" label="37" color="#fefeff"/>
-            <paletteEntry alpha="255" value="38" label="38" color="#cacaca"/>
-            <paletteEntry alpha="255" value="39" label="39" color="#969696"/>
-            <paletteEntry alpha="255" value="40" label="40" color="#969696"/>
-            <paletteEntry alpha="255" value="41" label="41" color="#969696"/>
-            <paletteEntry alpha="255" value="42" label="42" color="#969696"/>
-            <paletteEntry alpha="255" value="43" label="43" color="#969696"/>
-            <paletteEntry alpha="255" value="44" label="44" color="#969696"/>
-            <paletteEntry alpha="255" value="45" label="45" color="#969696"/>
-            <paletteEntry alpha="255" value="46" label="46" color="#969696"/>
-            <paletteEntry alpha="255" value="47" label="47" color="#969696"/>
-            <paletteEntry alpha="255" value="48" label="48" color="#969696"/>
-            <paletteEntry alpha="255" value="49" label="49" color="#969696"/>
-            <paletteEntry alpha="255" value="50" label="50" color="#969696"/>
-            <paletteEntry alpha="255" value="51" label="51" color="#969696"/>
-            <paletteEntry alpha="255" value="52" label="52" color="#969696"/>
-            <paletteEntry alpha="255" value="53" label="53" color="#969696"/>
-            <paletteEntry alpha="255" value="54" label="54" color="#969696"/>
-            <paletteEntry alpha="255" value="55" label="55" color="#969696"/>
-            <paletteEntry alpha="255" value="56" label="56" color="#969696"/>
-            <paletteEntry alpha="255" value="57" label="57" color="#969696"/>
-            <paletteEntry alpha="255" value="58" label="58" color="#969696"/>
-            <paletteEntry alpha="255" value="59" label="59" color="#969696"/>
-            <paletteEntry alpha="255" value="60" label="60" color="#969696"/>
-            <paletteEntry alpha="255" value="61" label="61" color="#969696"/>
-            <paletteEntry alpha="255" value="62" label="62" color="#969696"/>
-            <paletteEntry alpha="255" value="63" label="63" color="#969696"/>
-            <paletteEntry alpha="255" value="64" label="64" color="#969696"/>
-            <paletteEntry alpha="255" value="65" label="65" color="#969696"/>
-            <paletteEntry alpha="255" value="66" label="66" color="#969696"/>
-            <paletteEntry alpha="255" value="67" label="67" color="#969696"/>
-            <paletteEntry alpha="255" value="68" label="68" color="#969696"/>
-            <paletteEntry alpha="255" value="69" label="69" color="#969696"/>
-            <paletteEntry alpha="255" value="70" label="70" color="#969696"/>
-            <paletteEntry alpha="255" value="71" label="71" color="#969696"/>
-            <paletteEntry alpha="255" value="72" label="72" color="#969696"/>
-            <paletteEntry alpha="255" value="73" label="73" color="#969696"/>
-            <paletteEntry alpha="255" value="74" label="74" color="#969696"/>
-            <paletteEntry alpha="255" value="75" label="75" color="#969696"/>
-            <paletteEntry alpha="255" value="76" label="76" color="#969696"/>
-            <paletteEntry alpha="255" value="77" label="77" color="#969696"/>
-            <paletteEntry alpha="255" value="78" label="78" color="#969696"/>
-            <paletteEntry alpha="255" value="79" label="79" color="#969696"/>
-            <paletteEntry alpha="255" value="80" label="80" color="#969696"/>
-            <paletteEntry alpha="255" value="81" label="81" color="#969696"/>
-            <paletteEntry alpha="255" value="82" label="82" color="#969696"/>
-            <paletteEntry alpha="255" value="83" label="83" color="#969696"/>
-            <paletteEntry alpha="255" value="84" label="84" color="#969696"/>
-            <paletteEntry alpha="255" value="85" label="85" color="#969696"/>
-            <paletteEntry alpha="255" value="86" label="86" color="#969696"/>
-            <paletteEntry alpha="255" value="87" label="87" color="#969696"/>
-            <paletteEntry alpha="255" value="88" label="88" color="#969696"/>
-            <paletteEntry alpha="255" value="89" label="89" color="#969696"/>
-            <paletteEntry alpha="255" value="90" label="90" color="#969696"/>
-            <paletteEntry alpha="255" value="91" label="91" color="#969696"/>
-            <paletteEntry alpha="255" value="92" label="92" color="#969696"/>
-            <paletteEntry alpha="255" value="93" label="93" color="#969696"/>
-            <paletteEntry alpha="255" value="94" label="94" color="#969696"/>
-            <paletteEntry alpha="255" value="95" label="95" color="#969696"/>
-            <paletteEntry alpha="255" value="96" label="96" color="#969696"/>
-            <paletteEntry alpha="255" value="97" label="97" color="#969696"/>
-            <paletteEntry alpha="255" value="98" label="98" color="#969696"/>
-            <paletteEntry alpha="255" value="99" label="99" color="#969696"/>
-            <paletteEntry alpha="255" value="100" label="100" color="#969696"/>
-            <paletteEntry alpha="255" value="101" label="101" color="#969696"/>
-            <paletteEntry alpha="255" value="102" label="102" color="#969696"/>
-            <paletteEntry alpha="255" value="103" label="103" color="#969696"/>
-            <paletteEntry alpha="255" value="104" label="104" color="#969696"/>
-            <paletteEntry alpha="255" value="105" label="105" color="#969696"/>
-            <paletteEntry alpha="255" value="106" label="106" color="#969696"/>
-            <paletteEntry alpha="255" value="107" label="107" color="#969696"/>
-            <paletteEntry alpha="255" value="108" label="108" color="#969696"/>
-            <paletteEntry alpha="255" value="109" label="109" color="#969696"/>
-            <paletteEntry alpha="255" value="110" label="110" color="#969696"/>
-            <paletteEntry alpha="255" value="111" label="111" color="#969696"/>
-            <paletteEntry alpha="255" value="112" label="112" color="#969696"/>
-            <paletteEntry alpha="255" value="113" label="113" color="#969696"/>
-            <paletteEntry alpha="255" value="114" label="114" color="#969696"/>
-            <paletteEntry alpha="255" value="115" label="115" color="#969696"/>
-            <paletteEntry alpha="255" value="116" label="116" color="#969696"/>
-            <paletteEntry alpha="255" value="117" label="117" color="#969696"/>
-            <paletteEntry alpha="255" value="118" label="118" color="#969696"/>
-            <paletteEntry alpha="255" value="119" label="119" color="#969696"/>
-            <paletteEntry alpha="255" value="120" label="120" color="#969696"/>
-            <paletteEntry alpha="255" value="121" label="121" color="#969696"/>
-            <paletteEntry alpha="255" value="122" label="122" color="#969696"/>
-            <paletteEntry alpha="255" value="123" label="123" color="#969696"/>
-            <paletteEntry alpha="255" value="124" label="124" color="#969696"/>
-            <paletteEntry alpha="255" value="125" label="125" color="#969696"/>
-            <paletteEntry alpha="255" value="126" label="126" color="#969696"/>
-            <paletteEntry alpha="255" value="127" label="127" color="#969696"/>
-            <paletteEntry alpha="255" value="128" label="128" color="#969696"/>
-            <paletteEntry alpha="255" value="129" label="129" color="#969696"/>
-            <paletteEntry alpha="255" value="130" label="130" color="#969696"/>
-            <paletteEntry alpha="255" value="131" label="131" color="#969696"/>
-            <paletteEntry alpha="255" value="132" label="132" color="#969696"/>
-            <paletteEntry alpha="255" value="133" label="133" color="#969696"/>
-            <paletteEntry alpha="255" value="134" label="134" color="#969696"/>
-            <paletteEntry alpha="255" value="135" label="135" color="#969696"/>
-            <paletteEntry alpha="255" value="136" label="136" color="#969696"/>
-            <paletteEntry alpha="255" value="137" label="137" color="#969696"/>
-            <paletteEntry alpha="255" value="138" label="138" color="#969696"/>
-            <paletteEntry alpha="255" value="139" label="139" color="#969696"/>
-            <paletteEntry alpha="255" value="140" label="140" color="#969696"/>
-            <paletteEntry alpha="255" value="141" label="141" color="#969696"/>
-            <paletteEntry alpha="255" value="142" label="142" color="#969696"/>
-            <paletteEntry alpha="255" value="143" label="143" color="#969696"/>
-            <paletteEntry alpha="255" value="144" label="144" color="#969696"/>
-            <paletteEntry alpha="255" value="145" label="145" color="#969696"/>
-            <paletteEntry alpha="255" value="146" label="146" color="#969696"/>
-            <paletteEntry alpha="255" value="147" label="147" color="#969696"/>
-            <paletteEntry alpha="255" value="148" label="148" color="#969696"/>
-            <paletteEntry alpha="255" value="149" label="149" color="#969696"/>
-            <paletteEntry alpha="255" value="150" label="150" color="#969696"/>
-            <paletteEntry alpha="255" value="151" label="151" color="#969696"/>
-            <paletteEntry alpha="255" value="152" label="152" color="#969696"/>
-            <paletteEntry alpha="255" value="153" label="153" color="#969696"/>
-            <paletteEntry alpha="255" value="154" label="154" color="#969696"/>
-            <paletteEntry alpha="255" value="155" label="155" color="#969696"/>
-            <paletteEntry alpha="255" value="156" label="156" color="#969696"/>
-            <paletteEntry alpha="255" value="157" label="157" color="#969696"/>
-            <paletteEntry alpha="255" value="158" label="158" color="#969696"/>
-            <paletteEntry alpha="255" value="159" label="159" color="#969696"/>
-            <paletteEntry alpha="255" value="160" label="160" color="#969696"/>
-            <paletteEntry alpha="255" value="161" label="161" color="#969696"/>
-            <paletteEntry alpha="255" value="162" label="162" color="#969696"/>
-            <paletteEntry alpha="255" value="163" label="163" color="#969696"/>
-            <paletteEntry alpha="255" value="164" label="164" color="#969696"/>
-            <paletteEntry alpha="255" value="165" label="165" color="#969696"/>
-            <paletteEntry alpha="255" value="166" label="166" color="#969696"/>
-            <paletteEntry alpha="255" value="167" label="167" color="#969696"/>
-            <paletteEntry alpha="255" value="168" label="168" color="#969696"/>
-            <paletteEntry alpha="255" value="169" label="169" color="#969696"/>
-            <paletteEntry alpha="255" value="170" label="170" color="#969696"/>
-            <paletteEntry alpha="255" value="171" label="171" color="#969696"/>
-            <paletteEntry alpha="255" value="172" label="172" color="#969696"/>
-            <paletteEntry alpha="255" value="173" label="173" color="#969696"/>
-            <paletteEntry alpha="255" value="174" label="174" color="#969696"/>
-            <paletteEntry alpha="255" value="175" label="175" color="#969696"/>
-            <paletteEntry alpha="255" value="176" label="176" color="#969696"/>
-            <paletteEntry alpha="255" value="177" label="177" color="#969696"/>
-            <paletteEntry alpha="255" value="178" label="178" color="#969696"/>
-            <paletteEntry alpha="255" value="179" label="179" color="#969696"/>
-            <paletteEntry alpha="255" value="180" label="180" color="#969696"/>
-            <paletteEntry alpha="255" value="181" label="181" color="#969696"/>
-            <paletteEntry alpha="255" value="182" label="182" color="#969696"/>
-            <paletteEntry alpha="255" value="183" label="183" color="#969696"/>
-            <paletteEntry alpha="255" value="184" label="184" color="#969696"/>
-            <paletteEntry alpha="255" value="185" label="185" color="#969696"/>
-            <paletteEntry alpha="255" value="186" label="186" color="#969696"/>
-            <paletteEntry alpha="255" value="187" label="187" color="#969696"/>
-            <paletteEntry alpha="255" value="188" label="188" color="#969696"/>
-            <paletteEntry alpha="255" value="189" label="189" color="#969696"/>
-            <paletteEntry alpha="255" value="190" label="190" color="#969696"/>
-            <paletteEntry alpha="255" value="191" label="191" color="#969696"/>
-            <paletteEntry alpha="255" value="192" label="192" color="#969696"/>
-            <paletteEntry alpha="255" value="193" label="193" color="#969696"/>
-            <paletteEntry alpha="255" value="194" label="194" color="#969696"/>
-            <paletteEntry alpha="255" value="195" label="195" color="#969696"/>
-            <paletteEntry alpha="255" value="196" label="196" color="#969696"/>
-            <paletteEntry alpha="255" value="197" label="197" color="#969696"/>
-            <paletteEntry alpha="255" value="198" label="198" color="#969696"/>
-            <paletteEntry alpha="255" value="199" label="199" color="#969696"/>
-            <paletteEntry alpha="255" value="200" label="200" color="#969696"/>
-            <paletteEntry alpha="255" value="201" label="201" color="#969696"/>
-            <paletteEntry alpha="255" value="202" label="202" color="#969696"/>
-            <paletteEntry alpha="255" value="203" label="203" color="#969696"/>
-            <paletteEntry alpha="255" value="204" label="204" color="#969696"/>
-            <paletteEntry alpha="255" value="205" label="205" color="#969696"/>
-            <paletteEntry alpha="255" value="206" label="206" color="#969696"/>
-            <paletteEntry alpha="255" value="207" label="207" color="#969696"/>
-            <paletteEntry alpha="255" value="208" label="208" color="#969696"/>
-            <paletteEntry alpha="255" value="209" label="209" color="#969696"/>
-            <paletteEntry alpha="255" value="210" label="210" color="#969696"/>
-            <paletteEntry alpha="255" value="211" label="211" color="#969696"/>
-            <paletteEntry alpha="255" value="212" label="212" color="#969696"/>
-            <paletteEntry alpha="255" value="213" label="213" color="#969696"/>
-            <paletteEntry alpha="255" value="214" label="214" color="#969696"/>
-            <paletteEntry alpha="255" value="215" label="215" color="#969696"/>
-            <paletteEntry alpha="255" value="216" label="216" color="#969696"/>
-            <paletteEntry alpha="255" value="217" label="217" color="#969696"/>
-            <paletteEntry alpha="255" value="218" label="218" color="#969696"/>
-            <paletteEntry alpha="255" value="219" label="219" color="#969696"/>
-            <paletteEntry alpha="255" value="220" label="220" color="#969696"/>
-            <paletteEntry alpha="255" value="221" label="221" color="#969696"/>
-            <paletteEntry alpha="255" value="222" label="222" color="#969696"/>
-            <paletteEntry alpha="255" value="223" label="223" color="#969696"/>
-            <paletteEntry alpha="255" value="224" label="224" color="#969696"/>
-            <paletteEntry alpha="255" value="225" label="225" color="#969696"/>
-            <paletteEntry alpha="255" value="226" label="226" color="#969696"/>
-            <paletteEntry alpha="255" value="227" label="227" color="#969696"/>
-            <paletteEntry alpha="255" value="228" label="228" color="#969696"/>
-            <paletteEntry alpha="255" value="229" label="229" color="#969696"/>
-            <paletteEntry alpha="255" value="230" label="230" color="#969696"/>
-            <paletteEntry alpha="255" value="231" label="231" color="#969696"/>
-            <paletteEntry alpha="255" value="232" label="232" color="#969696"/>
-            <paletteEntry alpha="255" value="233" label="233" color="#969696"/>
-            <paletteEntry alpha="255" value="234" label="234" color="#969696"/>
-            <paletteEntry alpha="255" value="235" label="235" color="#969696"/>
-            <paletteEntry alpha="255" value="236" label="236" color="#969696"/>
-            <paletteEntry alpha="255" value="237" label="237" color="#969696"/>
-            <paletteEntry alpha="255" value="238" label="238" color="#969696"/>
-            <paletteEntry alpha="255" value="239" label="239" color="#969696"/>
-            <paletteEntry alpha="255" value="240" label="240" color="#969696"/>
-            <paletteEntry alpha="255" value="241" label="241" color="#969696"/>
-            <paletteEntry alpha="255" value="242" label="242" color="#969696"/>
-            <paletteEntry alpha="255" value="243" label="243" color="#969696"/>
-            <paletteEntry alpha="255" value="244" label="244" color="#969696"/>
-            <paletteEntry alpha="255" value="245" label="245" color="#969696"/>
-            <paletteEntry alpha="255" value="246" label="246" color="#969696"/>
-            <paletteEntry alpha="255" value="247" label="247" color="#969696"/>
-            <paletteEntry alpha="255" value="248" label="248" color="#969696"/>
-            <paletteEntry alpha="255" value="249" label="249" color="#969696"/>
-            <paletteEntry alpha="255" value="250" label="250" color="#969696"/>
-            <paletteEntry alpha="255" value="251" label="251" color="#969696"/>
-            <paletteEntry alpha="255" value="252" label="252" color="#969696"/>
-            <paletteEntry alpha="255" value="253" label="253" color="#969696"/>
-            <paletteEntry alpha="255" value="254" label="254" color="#969696"/>
-            <paletteEntry alpha="255" value="255" label="255" color="#ffffff"/>
-          </colorPalette>
+          <redContrastEnhancement>
+            <minValue>55</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>55</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>56</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="4" zoomedOutResampler="bilinear"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
     </maplayer>
-    <maplayer maxScale="0" hasScaleBasedVisibilityFlag="0" minScale="1e+8" autoRefreshEnabled="0" type="raster" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="">
+    <maplayer hasScaleBasedVisibilityFlag="1" legendPlaceholderImage="" minScale="35000" type="raster" styleCategories="AllStyleCategories" autoRefreshTime="0" refreshOnNotifyMessage="" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" maxScale="18000">
       <extent>
-        <xmin>2315000</xmin>
-        <ymin>913000</ymin>
-        <xmax>3059000</xmax>
-        <ymax>1415000</ymax>
+        <xmin>2570000</xmin>
+        <ymin>1208000</ymin>
+        <xmax>2667000</xmax>
+        <ymax>1268000</ymax>
       </extent>
-      <id>maske_f6e3da7d_dbef_4671_829f_b361337d3e44</id>
-      <datasource>/geodata/ch.so.agi.hintergrundkarte/maske.tif</datasource>
+      <wgs84extent>
+        <xmin>7.03999960003062686</xmin>
+        <ymin>47.01966393282929602</ymin>
+        <xmax>8.32884629598522253</xmax>
+        <ymax>47.56271008865905259</ymax>
+      </wgs84extent>
+      <id>ch_swisstopo_lk50_masked_grau_d75f5663_ef7f_4968_b7ae_21b65623f0f9</id>
+      <datasource>/geodata/ch.swisstopo.lk50.grau/ch.swisstopo.lk50-masked.grau.vrt</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>maske</layername>
+      <layername>ch.swisstopo.lk50-masked.grau</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-          <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
           <srsid>47</srsid>
           <srid>2056</srid>
           <authid>EPSG:2056</authid>
           <description>CH1903+ / LV95</description>
           <projectionacronym>somerc</projectionacronym>
-          <ellipsoidacronym>bessel</ellipsoidacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </srs>
@@ -2742,7 +2218,7 @@ def my_form_open(dialog, layer, feature):
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
+          <spatialrefsys nativeFormat="Wkt">
             <wkt></wkt>
             <proj4></proj4>
             <srsid>0</srsid>
@@ -2751,11 +2227,11 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial maxy="0" maxz="0" miny="0" crs="" dimensions="2" minx="0" maxx="0" minz="0"/>
+          <spatial crs="" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -2766,76 +2242,758 @@ def my_form_open(dialog, layer, feature):
       </resourceMetadata>
       <provider>gdal</provider>
       <noData>
-        <noDataList useSrcNoData="1" bandNo="1"/>
+        <noDataList useSrcNoData="0" bandNo="1"/>
+        <noDataList useSrcNoData="0" bandNo="2"/>
+        <noDataList useSrcNoData="0" bandNo="3"/>
+        <noDataList useSrcNoData="0" bandNo="4"/>
       </noData>
       <map-layer-style-manager current="default">
         <map-layer-style name="default"/>
       </map-layer-style-manager>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>0</Searchable>
+        <Private>0</Private>
       </flags>
-      <temporal enabled="0" mode="0" fetchMode="0">
+      <temporal mode="0" enabled="0" fetchMode="0">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
+      <elevation symbology="Line" zoffset="0" band="1" enabled="0" zscale="1">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="190,207,80,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="190,207,80,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0.26" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+      </elevation>
       <customproperties>
-        <property value="false" key="WMSBackgroundLayer"/>
-        <property value="false" key="WMSPublishDataSourceUrl"/>
-        <property value="0" key="embeddedWidgets/count"/>
-        <property value="Value" key="identify/format"/>
+        <Option type="Map">
+          <Option type="bool" value="false" name="WMSBackgroundLayer"/>
+          <Option type="bool" value="false" name="WMSPublishDataSourceUrl"/>
+          <Option type="int" value="0" name="embeddedWidgets/count"/>
+          <Option type="QString" value="Value" name="identify/format"/>
+        </Option>
       </customproperties>
+      <pipe-data-defined-properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </pipe-data-defined-properties>
       <pipe>
         <provider>
-          <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" enabled="false" zoomedInResamplingMethod="nearestNeighbour"/>
+          <resampling zoomedOutResamplingMethod="bilinear" zoomedInResamplingMethod="bilinear" enabled="false" maxOversampling="4"/>
         </provider>
-        <rasterrenderer nodataColor="" opacity="1" band="1" type="paletted" alphaBand="-1">
+        <rasterrenderer blueBand="3" type="multibandcolor" alphaBand="4" opacity="1" nodataColor="" greenBand="2" redBand="1">
           <rasterTransparency/>
           <minMaxOrigin>
-            <limits>None</limits>
+            <limits>MinMax</limits>
             <extent>WholeRaster</extent>
             <statAccuracy>Estimated</statAccuracy>
             <cumulativeCutLower>0.02</cumulativeCutLower>
             <cumulativeCutUpper>0.98</cumulativeCutUpper>
             <stdDevFactor>2</stdDevFactor>
           </minMaxOrigin>
-          <colorPalette>
-            <paletteEntry alpha="255" value="1" label="1" color="#ffffff"/>
-          </colorPalette>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
         </rasterrenderer>
         <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-        <huesaturation saturation="0" grayscaleMode="0" colorizeOn="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" colorizeStrength="100"/>
-        <rasterresampler maxOversampling="2"/>
+        <huesaturation grayscaleMode="0" invertColors="0" colorizeRed="255" saturation="0" colorizeBlue="128" colorizeOn="0" colorizeStrength="100" colorizeGreen="128"/>
+        <rasterresampler zoomedInResampler="bilinear" zoomedOutResampler="bilinear" maxOversampling="4"/>
         <resamplingStage>resamplingFilter</resamplingStage>
       </pipe>
       <blendMode>0</blendMode>
+    </maplayer>
+    <maplayer refreshOnNotifyMessage="" type="vector" legendPlaceholderImage="" geometry="Polygon" simplifyDrawingTol="1" wkbType="MultiPolygon" simplifyLocal="1" simplifyAlgorithm="0" autoRefreshEnabled="0" labelsEnabled="0" autoRefreshTime="0" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" minScale="100000000" simplifyMaxScale="1" readOnly="0" hasScaleBasedVisibilityFlag="0" maxScale="1" symbologyReferenceScale="-1">
+      <extent>
+        <xmin>2460000</xmin>
+        <ymin>1045000</ymin>
+        <xmax>2870000</xmax>
+        <ymax>1310000</ymax>
+      </extent>
+      <wgs84extent>
+        <xmin>5.56538564062858399</xmin>
+        <ymin>45.50330242777096146</ymin>
+        <xmax>11.0493926929830053</xmax>
+        <ymax>47.94040809862327279</ymax>
+      </wgs84extent>
+      <id>kantonsgrenze_generalisiert_6e83703b_0fdc_45fe_986b_017714cc1534</id>
+      <datasource>/geodata/ch.so.agi.av.hoheitsgrenzen/ch.so.agi.av.hoheitsgrenzen.gpkg|layername=kantonsgrenze_generalisiert</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>ch.so.agi.av.hoheitsgrenzen — kantonsgrenze_generalisiert</layername>
+      <srs>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+          <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>47</srsid>
+          <srid>2056</srid>
+          <authid>EPSG:2056</authid>
+          <description>CH1903+ / LV95</description>
+          <projectionacronym>somerc</projectionacronym>
+          <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+            <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+            <srsid>47</srsid>
+            <srid>2056</srid>
+            <authid>EPSG:2056</authid>
+            <description>CH1903+ / LV95</description>
+            <projectionacronym>somerc</projectionacronym>
+            <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial crs="EPSG:2056" maxy="0" minz="0" maxx="0" miny="0" minx="0" dimensions="2" maxz="0"/>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <metadataUrls/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+        <Private>0</Private>
+      </flags>
+      <temporal endExpression="" mode="0" endField="" durationField="" accumulate="0" startExpression="" fixedDuration="0" startField="" enabled="0" limitMode="0" durationUnit="min">
+        <fixedRange>
+          <start></start>
+          <end></end>
+        </fixedRange>
+      </temporal>
+      <elevation zoffset="0" symbology="Line" type="IndividualFeatures" respectLayerSymbol="1" clamping="Terrain" extrusionEnabled="0" showMarkerSymbolInSurfacePlots="0" extrusion="0" zscale="1" binding="Centroid">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="232,113,141,255" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.6" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="232,113,141,255" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="166,81,101,255" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol is_animated="0" alpha="1" type="marker" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="232,113,141,255" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="diamond" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="166,81,101,255" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0.2" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="3" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" type="invertedPolygonRenderer" preprocessing="0" enableorderby="0" referencescale="-1" symbollevels="0">
+        <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
+          <rules key="{de2768ff-ea4d-4503-aa80-b67d67c9d8b4}">
+            <rule scalemaxdenom="1000000" key="{76d24b68-698d-427c-ad8a-7b7ff8b037f3}" symbol="0" scalemindenom="50000"/>
+            <rule scalemaxdenom="10000000" key="{367d8915-7ef8-4ed7-8709-a55518081257}" symbol="1" scalemindenom="1000000"/>
+          </rules>
+          <symbols>
+            <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="0">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+                <Option type="Map">
+                  <Option type="QString" value="0" name="align_dash_pattern"/>
+                  <Option type="QString" value="square" name="capstyle"/>
+                  <Option type="QString" value="5;2" name="customdash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="customdash_unit"/>
+                  <Option type="QString" value="0" name="dash_pattern_offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                  <Option type="QString" value="1" name="draw_inside_polygon"/>
+                  <Option type="QString" value="bevel" name="joinstyle"/>
+                  <Option type="QString" value="253,191,111,128" name="line_color"/>
+                  <Option type="QString" value="solid" name="line_style"/>
+                  <Option type="QString" value="4" name="line_width"/>
+                  <Option type="QString" value="MM" name="line_width_unit"/>
+                  <Option type="QString" value="0" name="offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="offset_unit"/>
+                  <Option type="QString" value="0" name="ring_filter"/>
+                  <Option type="QString" value="0" name="trim_distance_end"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                  <Option type="QString" value="0" name="trim_distance_start"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                  <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                  <Option type="QString" value="0" name="use_custom_dash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+              <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+                <Option type="Map">
+                  <Option type="QString" value="0" name="align_dash_pattern"/>
+                  <Option type="QString" value="square" name="capstyle"/>
+                  <Option type="QString" value="5;2" name="customdash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="customdash_unit"/>
+                  <Option type="QString" value="0" name="dash_pattern_offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                  <Option type="QString" value="0" name="draw_inside_polygon"/>
+                  <Option type="QString" value="bevel" name="joinstyle"/>
+                  <Option type="QString" value="255,127,0,255" name="line_color"/>
+                  <Option type="QString" value="solid" name="line_style"/>
+                  <Option type="QString" value="0.26" name="line_width"/>
+                  <Option type="QString" value="MM" name="line_width_unit"/>
+                  <Option type="QString" value="0" name="offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="offset_unit"/>
+                  <Option type="QString" value="0" name="ring_filter"/>
+                  <Option type="QString" value="0" name="trim_distance_end"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                  <Option type="QString" value="0" name="trim_distance_start"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                  <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                  <Option type="QString" value="0" name="use_custom_dash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+            <symbol is_animated="0" alpha="1" type="fill" force_rhr="0" frame_rate="10" clip_to_extent="1" name="1">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+                <Option type="Map">
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                  <Option type="QString" value="255,127,0,255" name="color"/>
+                  <Option type="QString" value="bevel" name="joinstyle"/>
+                  <Option type="QString" value="0,0" name="offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="offset_unit"/>
+                  <Option type="QString" value="255,127,0,255" name="outline_color"/>
+                  <Option type="QString" value="solid" name="outline_style"/>
+                  <Option type="QString" value="0.26" name="outline_width"/>
+                  <Option type="QString" value="MM" name="outline_width_unit"/>
+                  <Option type="QString" value="no" name="style"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </symbols>
+        </renderer-v2>
+      </renderer-v2>
+      <customproperties>
+        <Option type="Map">
+          <Option type="QString" value="0" name="embeddedWidgets/count"/>
+          <Option type="invalid" name="variableNames"/>
+          <Option type="invalid" name="variableValues"/>
+        </Option>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory diagramOrientation="Up" labelPlacementMethod="XHeight" minScaleDenominator="1" minimumSize="0" width="15" backgroundAlpha="255" showAxis="0" backgroundColor="#ffffff" height="15" direction="1" penColor="#000000" scaleBasedVisibility="0" barWidth="5" lineSizeScale="3x:0,0,0,0,0,0" spacingUnit="MM" scaleDependency="Area" sizeType="MM" lineSizeType="MM" spacingUnitScale="3x:0,0,0,0,0,0" sizeScale="3x:0,0,0,0,0,0" penWidth="0" enabled="0" opacity="1" spacing="0" penAlpha="255" maxScaleDenominator="1e+08" rotationOffset="270">
+          <fontProperties description="Sans Serif,9,-1,5,50,0,0,0,0,0" strikethrough="0" italic="0" underline="0" bold="0" style=""/>
+          <attribute label="" color="#000000" colorOpacity="1" field=""/>
+          <axisSymbol>
+            <symbol is_animated="0" alpha="1" type="line" force_rhr="0" frame_rate="10" clip_to_extent="1" name="">
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+              <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+                <Option type="Map">
+                  <Option type="QString" value="0" name="align_dash_pattern"/>
+                  <Option type="QString" value="square" name="capstyle"/>
+                  <Option type="QString" value="5;2" name="customdash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="customdash_unit"/>
+                  <Option type="QString" value="0" name="dash_pattern_offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                  <Option type="QString" value="0" name="draw_inside_polygon"/>
+                  <Option type="QString" value="bevel" name="joinstyle"/>
+                  <Option type="QString" value="35,35,35,255" name="line_color"/>
+                  <Option type="QString" value="solid" name="line_style"/>
+                  <Option type="QString" value="0.26" name="line_width"/>
+                  <Option type="QString" value="MM" name="line_width_unit"/>
+                  <Option type="QString" value="0" name="offset"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="offset_unit"/>
+                  <Option type="QString" value="0" name="ring_filter"/>
+                  <Option type="QString" value="0" name="trim_distance_end"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                  <Option type="QString" value="0" name="trim_distance_start"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                  <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                  <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                  <Option type="QString" value="0" name="use_custom_dash"/>
+                  <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                </Option>
+                <data_defined_properties>
+                  <Option type="Map">
+                    <Option type="QString" value="" name="name"/>
+                    <Option name="properties"/>
+                    <Option type="QString" value="collection" name="type"/>
+                  </Option>
+                </data_defined_properties>
+              </layer>
+            </symbol>
+          </axisSymbol>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings zIndex="0" obstacle="0" placement="0" priority="0" dist="0" showAll="1" linePlacementFlags="2">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration type="Map">
+          <Option type="Map" name="QgsGeometryGapCheck">
+            <Option type="double" value="0" name="allowedGapsBuffer"/>
+            <Option type="bool" value="false" name="allowedGapsEnabled"/>
+            <Option type="QString" value="" name="allowedGapsLayer"/>
+          </Option>
+        </checkConfiguration>
+      </geometryOptions>
+      <legend type="default-vector" showLabelLegend="0"/>
+      <referencedLayers/>
+      <fieldConfiguration>
+        <field configurationFlags="None" name="T_Id">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="T_Ili_Tid">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="kantonsname">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="kantonskuerzel">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field configurationFlags="None" name="kantonsnummer">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias index="0" name="" field="T_Id"/>
+        <alias index="1" name="" field="T_Ili_Tid"/>
+        <alias index="2" name="" field="kantonsname"/>
+        <alias index="3" name="" field="kantonskuerzel"/>
+        <alias index="4" name="" field="kantonsnummer"/>
+      </aliases>
+      <defaults>
+        <default applyOnUpdate="0" expression="" field="T_Id"/>
+        <default applyOnUpdate="0" expression="" field="T_Ili_Tid"/>
+        <default applyOnUpdate="0" expression="" field="kantonsname"/>
+        <default applyOnUpdate="0" expression="" field="kantonskuerzel"/>
+        <default applyOnUpdate="0" expression="" field="kantonsnummer"/>
+      </defaults>
+      <constraints>
+        <constraint constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1" field="T_Id"/>
+        <constraint constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0" field="T_Ili_Tid"/>
+        <constraint constraints="1" exp_strength="0" unique_strength="0" notnull_strength="1" field="kantonsname"/>
+        <constraint constraints="1" exp_strength="0" unique_strength="0" notnull_strength="1" field="kantonskuerzel"/>
+        <constraint constraints="1" exp_strength="0" unique_strength="0" notnull_strength="1" field="kantonsnummer"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint exp="" desc="" field="T_Id"/>
+        <constraint exp="" desc="" field="T_Ili_Tid"/>
+        <constraint exp="" desc="" field="kantonsname"/>
+        <constraint exp="" desc="" field="kantonskuerzel"/>
+        <constraint exp="" desc="" field="kantonsnummer"/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column type="actions" hidden="1" width="-1"/>
+          <column type="field" hidden="0" width="-1" name="kantonsname"/>
+          <column type="field" hidden="0" width="-1" name="kantonskuerzel"/>
+          <column type="field" hidden="0" width="-1" name="T_Id"/>
+          <column type="field" hidden="0" width="-1" name="T_Ili_Tid"/>
+          <column type="field" hidden="0" width="-1" name="kantonsnummer"/>
+        </columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <storedexpressions/>
+      <editform tolerant="1">.</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath>.</editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field editable="1" name="T_Id"/>
+        <field editable="1" name="T_Ili_Tid"/>
+        <field editable="1" name="kantonskuerzel"/>
+        <field editable="1" name="kantonsname"/>
+        <field editable="1" name="kantonsnummer"/>
+      </editable>
+      <labelOnTop>
+        <field name="T_Id" labelOnTop="0"/>
+        <field name="T_Ili_Tid" labelOnTop="0"/>
+        <field name="kantonskuerzel" labelOnTop="0"/>
+        <field name="kantonsname" labelOnTop="0"/>
+        <field name="kantonsnummer" labelOnTop="0"/>
+      </labelOnTop>
+      <reuseLastValue>
+        <field name="T_Id" reuseLastValue="0"/>
+        <field name="T_Ili_Tid" reuseLastValue="0"/>
+        <field name="kantonskuerzel" reuseLastValue="0"/>
+        <field name="kantonsname" reuseLastValue="0"/>
+        <field name="kantonsnummer" reuseLastValue="0"/>
+      </reuseLastValue>
+      <dataDefinedFieldProperties/>
+      <widgets/>
+      <previewExpression>"T_Id"</previewExpression>
+      <mapTip></mapTip>
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="lk10_grau_relief_483ec29d_51d2_4dd1_9e59_03dd92ff5981"/>
-    <layer id="lk25_grau_eea4cf2f_880c_47c7_a6d0_af9334bc87d6"/>
-    <layer id="lk50_grau_cec4728a_148c_4f79_82cb_060463e19d71"/>
-    <layer id="lk100_grau_6c408079_3ce5_41f4_8804_ce76384d857f"/>
-    <layer id="lk200_grau_e12b1615_28d6_4f6e_b42e_016d8c29cda5"/>
-    <layer id="PK500_LV95_KGRS_Mosaic_2016_046ef77b_93fa_4ab5_a57d_921633c6a1c5"/>
-    <layer id="lk1000_grau_relief_5c6cf74e_981f_4641_abfc_d74b55e6e02e"/>
-    <layer id="maske_f6e3da7d_dbef_4671_829f_b361337d3e44"/>
-    <layer id="hoheitsgrenzen_kantonsgrenze_c3fe2463_ab1d_4a5c_80be_2c8fd98c1002"/>
+    <layer id="ch_swisstopo_lk10_masked_grau_relief_c621e4bd_2c35_490c_a66e_185d91d96663"/>
+    <layer id="ch_swisstopo_lk25_masked_grau_c84f613e_12e8_4d93_8e56_cd85bdc3d065"/>
+    <layer id="ch_swisstopo_lk50_masked_grau_d75f5663_ef7f_4968_b7ae_21b65623f0f9"/>
+    <layer id="ch_swisstopo_lk100_masked_grau_8f483ef0_731f_4ba3_bbe2_13c604f03589"/>
+    <layer id="ch_swisstopo_lk200_masked_grau_a274694a_01b5_4f25_90de_42e543e1b247"/>
+    <layer id="ch_swisstopo_lk500_masked_grau_b0758e40_6ec8_486b_9882_1eaf90551462"/>
+    <layer id="ch_swisstopo_lk1000_masked_grau_relief_3e6eca9b_1aaa_4a1c_95c3_2944ee4206e2"/>
+    <layer id="kantonsgrenze_generalisiert_6e83703b_0fdc_45fe_986b_017714cc1534"/>
+    <layer id="ch_so_agi_av_hoheitsgrenzen___kantonsgrenze_generalisiert_d0ee6c11_f9f9_474e_956b_d86f645720ce"/>
   </layerorder>
   <properties>
-    <DefaultStyles>
-      <ColorRamp type="QString"></ColorRamp>
-      <Fill type="QString"></Fill>
-      <Line type="QString"></Line>
-      <Marker type="QString"></Marker>
-      <Opacity type="double">1</Opacity>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
     <Digitizing>
-      <AvoidIntersectionsMode type="int">2</AvoidIntersectionsMode>
+      <AvoidIntersectionsMode type="int">0</AvoidIntersectionsMode>
     </Digitizing>
     <Gui>
       <CanvasColorBluePart type="int">255</CanvasColorBluePart>
@@ -2853,21 +3011,18 @@ def my_form_open(dialog, layer, feature):
       <pythonCode type="QString"></pythonCode>
     </Macros>
     <Measure>
-      <Ellipsoid type="QString">NONE</Ellipsoid>
+      <Ellipsoid type="QString">EPSG:7004</Ellipsoid>
     </Measure>
     <Measurement>
       <AreaUnits type="QString">m2</AreaUnits>
       <DistanceUnits type="QString">meters</DistanceUnits>
     </Measurement>
     <PAL>
-      <CandidatesLine type="int">50</CandidatesLine>
       <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
-      <CandidatesPoint type="int">16</CandidatesPoint>
-      <CandidatesPolygon type="int">30</CandidatesPolygon>
       <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
       <DrawRectOnly type="bool">false</DrawRectOnly>
       <DrawUnplaced type="bool">false</DrawUnplaced>
-      <PlacementEngineVersion type="int">0</PlacementEngineVersion>
+      <PlacementEngineVersion type="int">1</PlacementEngineVersion>
       <SearchMethod type="int">0</SearchMethod>
       <ShowingAllLabels type="bool">false</ShowingAllLabels>
       <ShowingCandidates type="bool">false</ShowingCandidates>
@@ -2876,13 +3031,13 @@ def my_form_open(dialog, layer, feature):
       <UnplacedColor type="QString">255,0,0,255</UnplacedColor>
     </PAL>
     <Paths>
-      <Absolute type="bool">true</Absolute>
+      <Absolute type="bool">false</Absolute>
     </Paths>
     <PositionPrecision>
       <Automatic type="bool">true</Automatic>
       <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">MU</DegreeFormat>
     </PositionPrecision>
+    <RenderMapTile type="bool">false</RenderMapTile>
     <SpatialRefSys>
       <ProjectionsEnabled type="int">1</ProjectionsEnabled>
     </SpatialRefSys>
@@ -2898,13 +3053,12 @@ def my_form_open(dialog, layer, feature):
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
     <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
     <WMSContactMail type="QString"></WMSContactMail>
-    <WMSContactOrganization type="QString">AGI SO</WMSContactOrganization>
+    <WMSContactOrganization type="QString">Kanton Solothurn, Amt für Geoinformation</WMSContactOrganization>
     <WMSContactPerson type="QString"></WMSContactPerson>
     <WMSContactPhone type="QString"></WMSContactPhone>
     <WMSContactPosition type="QString"></WMSContactPosition>
     <WMSCrsList type="QStringList">
       <value>EPSG:2056</value>
-      <value>EPSG:4326</value>
     </WMSCrsList>
     <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
     <WMSExtent type="QStringList">
@@ -2913,6 +3067,7 @@ def my_form_open(dialog, layer, feature):
       <value>2667000</value>
       <value>1268000</value>
     </WMSExtent>
+    <WMSFeatureInfoUseAttributeFormSettings type="bool">false</WMSFeatureInfoUseAttributeFormSettings>
     <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSImageQuality type="int">90</WMSImageQuality>
     <WMSKeywordList type="QStringList">
@@ -2921,13 +3076,11 @@ def my_form_open(dialog, layer, feature):
     <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
     <WMSOnlineResource type="QString"></WMSOnlineResource>
     <WMSPrecision type="QString">8</WMSPrecision>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSRestrictedLayers type="QStringList"/>
     <WMSRootName type="QString">ch.so.agi.hintergrundkarte_sw</WMSRootName>
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString"></WMSServiceAbstract>
     <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
-    <WMSServiceTitle type="QString">WMS for seeding ch.so.agi.hintergrundkarte_sw</WMSServiceTitle>
+    <WMSServiceTitle type="QString">WMS for seeding of ch.so.agi.hintergrundkarte_sw</WMSServiceTitle>
     <WMSTileBuffer type="int">0</WMSTileBuffer>
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
@@ -2955,9 +3108,9 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option type="QString" value="" name="name"/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option type="QString" value="collection" name="type"/>
     </Option>
   </dataDefinedServerProperties>
   <visibility-presets/>
@@ -2967,7 +3120,7 @@ def my_form_open(dialog, layer, feature):
     <parentidentifier></parentidentifier>
     <language></language>
     <type></type>
-    <title>ch.so.agi.hintergrundkarte_sw</title>
+    <title></title>
     <abstract></abstract>
     <contact>
       <name></name>
@@ -2979,41 +3132,78 @@ def my_form_open(dialog, layer, feature):
       <role></role>
     </contact>
     <links/>
-    <author>AGI</author>
-    <creation>2020-06-05T14:38:26</creation>
+    <author></author>
+    <creation>2025-07-07T11:14:45</creation>
   </projectMetadata>
   <Annotations/>
   <Layouts/>
+  <mapViewDocks3D/>
   <Bookmarks/>
-  <ProjectViewSettings UseProjectScales="0">
+  <ProjectViewSettings rotation="0" UseProjectScales="0">
     <Scales/>
-    <DefaultViewExtent ymax="1238069.60587927489541471" xmin="2609557.09051607782021165" xmax="2611507.06968473317101598" ymin="1236947.77254479727707803">
-      <spatialrefsys>
-        <wkt>PROJCS["CH1903+ / LV95",GEOGCS["CH1903+",DATUM["CH1903+",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],TOWGS84[674.374,15.056,405.346,0,0,0,0],AUTHORITY["EPSG","6150"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4150"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.95240555555556],PARAMETER["longitude_of_center",7.439583333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",2600000],PARAMETER["false_northing",1200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","2056"]]</wkt>
-        <proj4>+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
+    <DefaultViewExtent xmin="2563525.93010146543383598" xmax="2673474.06989853456616402" ymax="1269500" ymin="1206500">
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>PROJCRS["CH1903+ / LV95",BASEGEOGCRS["CH1903+",DATUM["CH1903+",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4150]],CONVERSION["Swiss Oblique Mercator 1995",METHOD["Hotine Oblique Mercator (variant B)",ID["EPSG",9815]],PARAMETER["Latitude of projection centre",46.9524055555556,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8811]],PARAMETER["Longitude of projection centre",7.43958333333333,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8812]],PARAMETER["Azimuth of initial line",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8813]],PARAMETER["Angle from Rectified to Skew Grid",90,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8814]],PARAMETER["Scale factor on initial line",1,SCALEUNIT["unity",1],ID["EPSG",8815]],PARAMETER["Easting at projection centre",2600000,LENGTHUNIT["metre",1],ID["EPSG",8816]],PARAMETER["Northing at projection centre",1200000,LENGTHUNIT["metre",1],ID["EPSG",8817]]],CS[Cartesian,2],AXIS["(E)",east,ORDER[1],LENGTHUNIT["metre",1]],AXIS["(N)",north,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Cadastre, engineering survey, topographic mapping (large and medium scale)."],AREA["Liechtenstein; Switzerland."],BBOX[45.82,5.96,47.81,10.49]],ID["EPSG",2056]]</wkt>
+        <proj4>+proj=somerc +lat_0=46.9524055555556 +lon_0=7.43958333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs</proj4>
         <srsid>47</srsid>
         <srid>2056</srid>
         <authid>EPSG:2056</authid>
         <description>CH1903+ / LV95</description>
         <projectionacronym>somerc</projectionacronym>
-        <ellipsoidacronym>bessel</ellipsoidacronym>
+        <ellipsoidacronym>EPSG:7004</ellipsoidacronym>
         <geographicflag>false</geographicflag>
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h"/>
-  <ProjectDisplaySettings>
+  <ProjectStyleSettings projectStyleId="attachment:///LLbqrL_styles.db" RandomizeDefaultSymbolColor="1" DefaultSymbolOpacity="1">
+    <databases/>
+  </ProjectStyleSettings>
+  <ProjectTimeSettings timeStepUnit="h" frameRate="1" timeStep="1" cumulativeTemporalRange="0"/>
+  <ElevationProperties>
+    <terrainProvider type="flat">
+      <TerrainProvider offset="0" scale="1"/>
+    </terrainProvider>
+  </ElevationProperties>
+  <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
     <BearingFormat id="bearing">
       <Option type="Map">
-        <Option value="" name="decimal_separator" type="QChar"/>
-        <Option value="6" name="decimals" type="int"/>
-        <Option value="0" name="direction_format" type="int"/>
-        <Option value="0" name="rounding_type" type="int"/>
-        <Option value="false" name="show_plus" type="bool"/>
-        <Option value="true" name="show_thousand_separator" type="bool"/>
-        <Option value="false" name="show_trailing_zeros" type="bool"/>
-        <Option value="" name="thousand_separator" type="QChar"/>
+        <Option type="invalid" name="decimal_separator"/>
+        <Option type="int" value="6" name="decimals"/>
+        <Option type="int" value="0" name="direction_format"/>
+        <Option type="int" value="0" name="rounding_type"/>
+        <Option type="bool" value="false" name="show_plus"/>
+        <Option type="bool" value="true" name="show_thousand_separator"/>
+        <Option type="bool" value="false" name="show_trailing_zeros"/>
+        <Option type="invalid" name="thousand_separator"/>
       </Option>
     </BearingFormat>
+    <GeographicCoordinateFormat id="geographiccoordinate">
+      <Option type="Map">
+        <Option type="QString" value="DecimalDegrees" name="angle_format"/>
+        <Option type="invalid" name="decimal_separator"/>
+        <Option type="int" value="6" name="decimals"/>
+        <Option type="int" value="0" name="rounding_type"/>
+        <Option type="bool" value="false" name="show_leading_degree_zeros"/>
+        <Option type="bool" value="false" name="show_leading_zeros"/>
+        <Option type="bool" value="false" name="show_plus"/>
+        <Option type="bool" value="false" name="show_suffix"/>
+        <Option type="bool" value="true" name="show_thousand_separator"/>
+        <Option type="bool" value="false" name="show_trailing_zeros"/>
+        <Option type="invalid" name="thousand_separator"/>
+      </Option>
+    </GeographicCoordinateFormat>
+    <CoordinateCustomCrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </CoordinateCustomCrs>
   </ProjectDisplaySettings>
 </qgis>


### PR DESCRIPTION
Updates various aspects of the seeding process:
* Raster data is stored in a new remote location
* Download ch.so.agi.av.hoheitsgrenzen.gpkg.zip instead of generating them with ogr2ogr
* Reduce extent of raster data
* Use QGIS Docker container für editing the .qgs files
* Run the seeder container with the local UID
* Use only one Docker Compose service ("wmts") for seeding and for serving the tiles
* Completely new versions of `qgs/ch.so.agi.hintergrundkarte_farbig.qgs` and `qgs/ch.so.agi.hintergrundkarte_sw.qgs`